### PR TITLE
ci: publish package previews with pkg-pr-new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,21 @@ jobs:
       # no-op until they do.
       - name: Test
         run: npm test --workspace ${{ matrix.workspace }} --if-present
+
+  preview:
+    name: preview package
+    if: github.event_name == 'pull_request'
+    needs: [package, example]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      - uses: ./.github/actions/install
+
+      - run: npm run build --workspaces --if-present
+
+      - run: npx pkg-pr-new publish --peerDeps ./packages/workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ on:
       - "docs/**"
       - ".github/**/*.md"
 
+permissions:
+  contents: read
+
 concurrency:
   # PRs key on the PR number so successive pushes cancel the prior
   # run; pushes to main key on the ref so we never cancel a main

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@biomejs/biome": "^2.4.16",
         "@types/node": "^25.9.1",
         "esbuild": "^0.28.1",
+        "pkg-pr-new": "^0.0.75",
         "postject": "^1.0.0-alpha.6",
         "sherif": "^1.11.1",
         "typescript": "^6.0.3"
@@ -9359,6 +9360,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-pr-new": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.75.tgz",
+      "integrity": "sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pkg-pr-new": "bin/cli.js"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@biomejs/biome": "^2.4.16",
     "@types/node": "^25.9.1",
     "esbuild": "^0.28.1",
+    "pkg-pr-new": "^0.0.75",
     "postject": "^1.0.0-alpha.6",
     "sherif": "^1.11.1",
     "typescript": "^6.0.3"


### PR DESCRIPTION
This adds the same `pkg-pr-new` dependency and publish command used by `cloudflare/agents`. A dedicated preview job waits for every package and example check, builds the monorepo once, then publishes `./packages/workspace`. Keeping publication in one job avoids duplicate previews from the existing test matrix.