### PR TITLE
Unify the backend connect signature on one host-injected shape

### DIFF
--- a/packages/computer/src/backend.ts
+++ b/packages/computer/src/backend.ts
@@ -20,6 +20,22 @@
 
 import type { WorkspaceRPC } from "@cloudflare/computer-rpc";
 
+// The handles the Workspace owns and injects into a backend when
+// it connects. The Workspace constructor builds `db`/`fs` itself,
+// after the caller has already constructed the backends and passed
+// them in, so a backend cannot capture them at its own
+// construction time. `connect(host)` is how the Workspace hands
+// over the storage-layer handles once they exist. Shell and
+// container backends ignore the bag (they reach the host through
+// their own transport); the in-process module backend uses it.
+export interface WorkspaceBackendHost {
+  readonly db: import("@cloudflare/dofs").Database;
+  readonly waitUntil?: (promise: Promise<unknown>) => void;
+  readonly fs: import("@cloudflare/dofs").WorkspaceFilesystem;
+  readonly git: import("./git/index.js").GitClient;
+  readonly artifacts: import("./artifacts/index.js").ArtifactClient;
+}
+
 export interface WorkspaceBackend {
   // User-supplied selector. Passed in `ExecOptions.backend` and
   // `Workspace.push(id)` / `Workspace.pull(id)` to address this
@@ -48,8 +64,10 @@ export interface WorkspaceBackend {
   // Materialise a connection. Called lazily on first use, once
   // per backend per workspace lifetime. The Workspace caches the
   // resulting handle by `id`; subsequent exec / push / pull
-  // calls reuse it.
-  connect(): Promise<BackendHandle>;
+  // calls reuse it. The Workspace always passes its host bag;
+  // backends that reach the host through their own transport
+  // ignore it.
+  connect(host: WorkspaceBackendHost): Promise<BackendHandle>;
 }
 
 export interface BackendHandle {

--- a/packages/computer/src/runtime/types.ts
+++ b/packages/computer/src/runtime/types.ts
@@ -160,14 +160,7 @@ export interface WorkspaceModuleBackendHandle {
   close(): Promise<void>;
 }
 
-export interface WorkspaceModuleBackendHost {
-  readonly db: import("@cloudflare/dofs").Database;
-  /** Attach detached backend work to the host event lifetime. */
-  readonly waitUntil?: (promise: Promise<unknown>) => void;
-  readonly fs: import("@cloudflare/dofs").WorkspaceFilesystem;
-  readonly git: import("../git/index.js").GitClient;
-  readonly artifacts: import("../artifacts/index.js").ArtifactClient;
-}
+export type WorkspaceModuleBackendHost = import("../backend.js").WorkspaceBackendHost;
 
 export interface WorkspaceModuleBackend {
   readonly protocol: "module";

--- a/packages/computer/src/workspace.ts
+++ b/packages/computer/src/workspace.ts
@@ -857,7 +857,14 @@ export class Workspace {
         this.#observer,
         "workspace.connect",
         { "workspace.backend.id": id, "workspace.backend.type": backend.type },
-        () => backend.connect(),
+        () =>
+          backend.connect({
+            db: this.#db,
+            waitUntil: this.#waitUntil,
+            fs: this.#fs,
+            git: this.git,
+            artifacts: this.#artifacts,
+          }),
       );
       if (generation !== this.#connectionGeneration) {
         await handle.close().catch(() => undefined);

--- a/packages/computer/src/workspace.ts
+++ b/packages/computer/src/workspace.ts
@@ -862,7 +862,7 @@ export class Workspace {
             db: this.#db,
             waitUntil: this.#waitUntil,
             fs: this.#fs,
-            git: this.git,
+            git: this.#gitFactory ? this.git : DISABLED_GIT_CLIENT,
             artifacts: this.#artifacts,
           }),
       );


### PR DESCRIPTION
The two backend interfaces took different `connect` signatures. The shell and container kind took a bare `connect()` and reached the host through a transport it captured when it was built. The JavaScript kind took a `connect(host)` that received the storage-layer handles the Workspace owns. The split was historical rather than necessary: the host bag exists only because the Workspace builds its database and filesystem handles after the caller has already constructed the backends and passed them in, so a backend cannot capture them at its own construction time.

This change gives every backend the same `connect(host)` signature and has the Workspace pass its host bag on every connect. Shell and container backends accept the bag and ignore it, reaching the host through their own transport as before; the JavaScript backend uses it as before. Because method parameters are compatible when an implementation ignores arguments the interface declares, the existing zero-argument implementations satisfy the wider signature without edits. The duplicate host type collapses onto one canonical definition.

This is internal plumbing. `connect` is called only by the Workspace itself, never by an example or other consumer, so there is no public-API impact. No behavior changes.

Verify with `npm test --workspace @cloudflare/computer` and `npm run typecheck`.
