### PR TITLE
Support callable backends and streaming
 in the exec tool

### DIFF
--- a/packages/computer/src/runtime/runtime.ts
+++ b/packages/computer/src/runtime/runtime.ts
@@ -34,6 +34,14 @@ export class WorkspaceRuntime {
     this.#options = options;
   }
 
+  // Whether the named backend accepts a structured `input` value and
+  // returns a structured result. Consumers such as the exec tool ask
+  // this to know whether a backend is callable without the caller
+  // having to declare it a second time.
+  isCallable(id: string): boolean {
+    return this.#options.callableBackendIds.has(id);
+  }
+
   exec(source: string): Promise<WorkspaceRuntimeExecHandle<undefined>>;
   exec(
     source: string,
@@ -49,7 +57,7 @@ export class WorkspaceRuntime {
   ): Promise<WorkspaceRuntimeExecHandle<E>> {
     if (options.id !== undefined) assertExecutionId(options.id);
     const backend = this.#backend(options.backend);
-    if (options.input !== undefined && !this.#options.callableBackendIds.has(backend)) {
+    if (options.input !== undefined && !this.isCallable(backend)) {
       throw new Error(notCallableMessage(backend));
     }
     const runtime = await this.#options.backendHandle(backend);

--- a/packages/computer/src/tools/ai.test.ts
+++ b/packages/computer/src/tools/ai.test.ts
@@ -43,7 +43,7 @@ type ExecStreamEvent =
   | { name: "stdout"; value: string }
   | { name: "stderr"; value: string }
   | { name: "result"; value: unknown }
-  | { name: "exit"; value: number };
+  | { name: "exit"; value: number; result?: unknown };
 
 function streamingHandle(events: ExecStreamEvent[]) {
   return {
@@ -747,6 +747,41 @@ describe("createAITools exec streaming", () => {
             { name: "stdout", value: "working\n" },
             { name: "result", value: { ok: true } },
             { name: "exit", value: 0 },
+          ]);
+        },
+      },
+    };
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "js",
+        backends: { js: { description: "JavaScript module runtime", callable: true } },
+      },
+    });
+
+    const chunks = await collectTool(tools.exec, {
+      command: "export default () => ({ ok: true })",
+      input: {},
+    });
+    expect(chunks).toHaveLength(2);
+    expect(chunks.at(-1)).toEqual({
+      command: "export default () => ({ ok: true })",
+      cwd: null,
+      backend: "js",
+      exitCode: 0,
+      stdout: "working\n",
+      stderr: "",
+      result: { ok: true },
+    });
+  });
+
+  it("reads a callable backend's result folded onto the exit event", async () => {
+    const workspace = {
+      runtime: {
+        async exec() {
+          return streamingHandle([
+            { name: "stdout", value: "working\n" },
+            { name: "exit", value: 0, result: { ok: true } },
           ]);
         },
       },

--- a/packages/computer/src/tools/ai.test.ts
+++ b/packages/computer/src/tools/ai.test.ts
@@ -552,6 +552,7 @@ describe("createAITools callable exec", () => {
             }),
           };
         },
+        isCallable: (id: string) => id === "js",
       },
     };
     const tools = createAITools({
@@ -559,7 +560,7 @@ describe("createAITools callable exec", () => {
       shell: {
         defaultBackend: "js",
         backends: {
-          js: { description: "JavaScript module runtime", callable: true },
+          js: { description: "JavaScript module runtime" },
         },
       },
     });
@@ -597,13 +598,14 @@ describe("createAITools callable exec", () => {
             result: async () => ({ exitCode: 0, stdout: "ok", stderr: "" }),
           };
         },
+        isCallable: (id: string) => id === "js",
       },
     };
     const tools = createAITools({
       workspace,
       shell: {
         defaultBackend: "js",
-        backends: { js: { description: "JavaScript module runtime", callable: true } },
+        backends: { js: { description: "JavaScript module runtime" } },
       },
     });
 
@@ -620,6 +622,7 @@ describe("createAITools callable exec", () => {
           called = true;
           return { result: async () => ({ exitCode: 0, stdout: "", stderr: "" }) };
         },
+        isCallable: (id: string) => id === "js",
       },
     };
     const tools = createAITools({
@@ -628,7 +631,7 @@ describe("createAITools callable exec", () => {
         defaultBackend: "shell",
         backends: {
           shell: { description: "fast shell" },
-          js: { description: "JavaScript module runtime", callable: true },
+          js: { description: "JavaScript module runtime" },
         },
       },
     });
@@ -674,13 +677,14 @@ describe("createAITools callable exec", () => {
         async exec() {
           throw new Error("not used");
         },
+        isCallable: (id: string) => id === "js",
       },
     };
     const tools = createAITools({
       workspace,
       shell: {
         defaultBackend: "js",
-        backends: { js: { description: "JavaScript module runtime", callable: true } },
+        backends: { js: { description: "JavaScript module runtime" } },
       },
     });
 
@@ -749,13 +753,14 @@ describe("createAITools exec streaming", () => {
             { name: "exit", value: 0 },
           ]);
         },
+        isCallable: (id: string) => id === "js",
       },
     };
     const tools = createAITools({
       workspace,
       shell: {
         defaultBackend: "js",
-        backends: { js: { description: "JavaScript module runtime", callable: true } },
+        backends: { js: { description: "JavaScript module runtime" } },
       },
     });
 
@@ -784,13 +789,14 @@ describe("createAITools exec streaming", () => {
             { name: "exit", value: 0, result: { ok: true } },
           ]);
         },
+        isCallable: (id: string) => id === "js",
       },
     };
     const tools = createAITools({
       workspace,
       shell: {
         defaultBackend: "js",
-        backends: { js: { description: "JavaScript module runtime", callable: true } },
+        backends: { js: { description: "JavaScript module runtime" } },
       },
     });
 

--- a/packages/computer/src/tools/ai.test.ts
+++ b/packages/computer/src/tools/ai.test.ts
@@ -55,6 +55,17 @@ function streamingHandle(events: ExecStreamEvent[]) {
   };
 }
 
+// A clock that advances 200ms per read, past the 100ms coalescing
+// floor, so every chunk produces its own running snapshot. Streaming
+// tests that assert per-chunk output inject this to defeat coalescing.
+function steppingClock(stepMs = 200): () => number {
+  let t = 0;
+  return () => {
+    t += stepMs;
+    return t;
+  };
+}
+
 function toolDescription(tool: unknown): string {
   const description = (tool as { description?: unknown }).description;
   if (typeof description !== "string") throw new Error("tool has no description");
@@ -710,6 +721,7 @@ describe("createAITools exec streaming", () => {
       shell: {
         defaultBackend: "shell",
         backends: { shell: { description: "fast shell" } },
+        now: steppingClock(),
       },
     });
 
@@ -835,6 +847,69 @@ describe("createAITools exec streaming", () => {
       cwd: null,
       backend: "shell",
       error: "stream broke",
+    });
+  });
+
+  it("coalesces running snapshots to at most one per interval", async () => {
+    const workspace = {
+      runtime: {
+        async exec() {
+          return streamingHandle([
+            { name: "stdout", value: "a" },
+            { name: "stdout", value: "b" },
+            { name: "stdout", value: "c" },
+            { name: "exit", value: 0 },
+          ]);
+        },
+      },
+    };
+    // A frozen clock never advances past the coalescing floor. The
+    // first chunk still yields a running snapshot for responsiveness;
+    // the later chunks coalesce into the terminal snapshot.
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "shell",
+        backends: { shell: { description: "fast shell" } },
+        now: () => 1000,
+      },
+    });
+
+    const chunks = await collectTool(tools.exec, { command: "run" });
+    expect(chunks).toEqual([
+      { command: "run", cwd: null, backend: "shell", exitCode: null, stdout: "a", stderr: "" },
+      { command: "run", cwd: null, backend: "shell", exitCode: 0, stdout: "abc", stderr: "" },
+    ]);
+  });
+
+  it("caps streamed output in memory at streamMaxBytes", async () => {
+    const workspace = {
+      runtime: {
+        async exec() {
+          return streamingHandle([
+            { name: "stdout", value: "a".repeat(10) },
+            { name: "stdout", value: "b".repeat(10) },
+            { name: "exit", value: 0 },
+          ]);
+        },
+      },
+    };
+    // Hold at most 12 bytes; show at most 8. The marker counts every
+    // byte seen (20), not just the 12 retained.
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "shell",
+        backends: { shell: { description: "fast shell" } },
+        maxBytes: 8,
+        streamMaxBytes: 12,
+      },
+    });
+
+    const chunks = await collectTool(tools.exec, { command: "run" });
+    expect(chunks.at(-1)).toMatchObject({
+      exitCode: 0,
+      stdout: "aaaaaaaa\n\n[truncated, 12 more bytes]",
     });
   });
 });

--- a/packages/computer/src/tools/ai.test.ts
+++ b/packages/computer/src/tools/ai.test.ts
@@ -17,7 +17,43 @@ async function executeTool(tool: unknown, input: unknown): Promise<unknown> {
   const execute = (tool as { execute?: (input: unknown, options: typeof toolOptions) => unknown })
     .execute;
   if (!execute) throw new Error("tool has no execute function");
-  return await execute(input, toolOptions);
+  const output = await execute(input, toolOptions);
+  if (output && typeof output === "object" && Symbol.asyncIterator in output) {
+    let last: unknown;
+    for await (const chunk of output as AsyncIterable<unknown>) last = chunk;
+    return last;
+  }
+  return output;
+}
+
+async function collectTool(tool: unknown, input: unknown): Promise<unknown[]> {
+  const execute = (tool as { execute?: (input: unknown, options: typeof toolOptions) => unknown })
+    .execute;
+  if (!execute) throw new Error("tool has no execute function");
+  const output = await execute(input, toolOptions);
+  if (!output || typeof output !== "object" || !(Symbol.asyncIterator in output)) {
+    return [output];
+  }
+  const chunks: unknown[] = [];
+  for await (const chunk of output as AsyncIterable<unknown>) chunks.push(chunk);
+  return chunks;
+}
+
+type ExecStreamEvent =
+  | { name: "stdout"; value: string }
+  | { name: "stderr"; value: string }
+  | { name: "result"; value: unknown }
+  | { name: "exit"; value: number };
+
+function streamingHandle(events: ExecStreamEvent[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const event of events) yield event;
+    },
+    result: async () => {
+      throw new Error("result() must not be called on a streamed handle");
+    },
+  };
 }
 
 function toolDescription(tool: unknown): string {
@@ -649,6 +685,154 @@ describe("createAITools callable exec", () => {
     });
 
     expect(toolDescription(tools.exec)).toContain("callable");
+  });
+});
+
+describe("createAITools exec streaming", () => {
+  it("streams stdout and stderr chunks and yields a final aggregate", async () => {
+    const workspace = {
+      runtime: {
+        async exec() {
+          return streamingHandle([
+            { name: "stdout", value: "one\n" },
+            { name: "stderr", value: "warn\n" },
+            { name: "stdout", value: "two\n" },
+            { name: "exit", value: 0 },
+          ]);
+        },
+      },
+    };
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "shell",
+        backends: { shell: { description: "fast shell" } },
+      },
+    });
+
+    await expect(collectTool(tools.exec, { command: "run" })).resolves.toEqual([
+      { command: "run", cwd: null, backend: "shell", exitCode: null, stdout: "one\n", stderr: "" },
+      {
+        command: "run",
+        cwd: null,
+        backend: "shell",
+        exitCode: null,
+        stdout: "one\n",
+        stderr: "warn\n",
+      },
+      {
+        command: "run",
+        cwd: null,
+        backend: "shell",
+        exitCode: null,
+        stdout: "one\ntwo\n",
+        stderr: "warn\n",
+      },
+      {
+        command: "run",
+        cwd: null,
+        backend: "shell",
+        exitCode: 0,
+        stdout: "one\ntwo\n",
+        stderr: "warn\n",
+      },
+    ]);
+  });
+
+  it("streams a callable backend's result value on the final chunk", async () => {
+    const workspace = {
+      runtime: {
+        async exec() {
+          return streamingHandle([
+            { name: "stdout", value: "working\n" },
+            { name: "result", value: { ok: true } },
+            { name: "exit", value: 0 },
+          ]);
+        },
+      },
+    };
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "js",
+        backends: { js: { description: "JavaScript module runtime", callable: true } },
+      },
+    });
+
+    const chunks = await collectTool(tools.exec, {
+      command: "export default () => ({ ok: true })",
+      input: {},
+    });
+    expect(chunks).toHaveLength(2);
+    expect(chunks.at(-1)).toEqual({
+      command: "export default () => ({ ok: true })",
+      cwd: null,
+      backend: "js",
+      exitCode: 0,
+      stdout: "working\n",
+      stderr: "",
+      result: { ok: true },
+    });
+  });
+
+  it("truncates streamed output on UTF-8 byte boundaries", async () => {
+    const workspace = {
+      runtime: {
+        async exec() {
+          return streamingHandle([
+            { name: "stdout", value: "a\u{1f642}b" },
+            { name: "exit", value: 0 },
+          ]);
+        },
+      },
+    };
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "shell",
+        backends: { shell: { description: "fast shell" } },
+        maxBytes: 5,
+      },
+    });
+
+    const chunks = await collectTool(tools.exec, { command: "echo emoji" });
+    expect(chunks.at(-1)).toMatchObject({
+      exitCode: 0,
+      stdout: "a\u{1f642}\n\n[truncated, 1 more bytes]",
+    });
+  });
+
+  it("yields a structured error when the stream fails mid-run", async () => {
+    const workspace = {
+      runtime: {
+        async exec() {
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield { name: "stdout", value: "partial\n" } as ExecStreamEvent;
+              throw new Error("stream broke");
+            },
+            result: async () => {
+              throw new Error("result() must not be called on a streamed handle");
+            },
+          };
+        },
+      },
+    };
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "shell",
+        backends: { shell: { description: "fast shell" } },
+      },
+    });
+
+    const chunks = await collectTool(tools.exec, { command: "run" });
+    expect(chunks.at(-1)).toEqual({
+      command: "run",
+      cwd: null,
+      backend: "shell",
+      error: "stream broke",
+    });
   });
 });
 

--- a/packages/computer/src/tools/ai.test.ts
+++ b/packages/computer/src/tools/ai.test.ts
@@ -988,6 +988,57 @@ describe("createAITools exec streaming", () => {
       stdout: "aaaaaaaa\n\n[truncated, 12 more bytes]",
     });
   });
+
+  it("kills the backend execution when the turn aborts", async () => {
+    let killed = 0;
+    const controller = new AbortController();
+    const workspace = {
+      runtime: {
+        async exec() {
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield { name: "stdout", value: "working\n" } as ExecStreamEvent;
+              controller.abort();
+              // The abort listener calls kill(); yield once more so
+              // the iteration observes the signal before the stream
+              // ends on its own.
+              yield { name: "exit", code: 130 } as ExecStreamEvent;
+            },
+            result: async () => {
+              throw new Error("result() must not be called on a streamed handle");
+            },
+            kill: async () => {
+              killed += 1;
+            },
+          };
+        },
+      },
+    };
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "shell",
+        backends: { shell: { description: "fast shell" } },
+      },
+    });
+
+    const execute = (
+      tools.exec as {
+        execute: (
+          input: unknown,
+          options: { toolCallId: string; messages: []; abortSignal: AbortSignal },
+        ) => AsyncIterable<unknown>;
+      }
+    ).execute;
+    const output = execute(
+      { command: "sleep" },
+      { toolCallId: "t", messages: [], abortSignal: controller.signal },
+    );
+    for await (const _chunk of output) {
+      // Drain to completion.
+    }
+    expect(killed).toBe(1);
+  });
 });
 
 describe("createAITools publish tool", () => {

--- a/packages/computer/src/tools/ai.test.ts
+++ b/packages/computer/src/tools/ai.test.ts
@@ -481,6 +481,177 @@ describe("createAITools exec tool", () => {
   });
 });
 
+describe("createAITools callable exec", () => {
+  it("forwards env and input to the runtime and returns the result value", async () => {
+    const calls: Array<{
+      command: string;
+      env: Record<string, string> | undefined;
+      input: unknown;
+      backend: string | undefined;
+    }> = [];
+    const workspace = {
+      runtime: {
+        async exec(
+          command: string,
+          options: {
+            cwd?: string;
+            encoding: "utf8";
+            backend?: string;
+            env?: Record<string, string>;
+            input?: unknown;
+          },
+        ) {
+          calls.push({
+            command,
+            env: options.env,
+            input: options.input,
+            backend: options.backend,
+          });
+          return {
+            result: async () => ({
+              exitCode: 0,
+              stdout: "ran",
+              stderr: "",
+              value: { doubled: 84 },
+            }),
+          };
+        },
+      },
+    };
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "js",
+        backends: {
+          js: { description: "JavaScript module runtime", callable: true },
+        },
+      },
+    });
+
+    await expect(
+      executeTool(tools.exec, {
+        command: "export default (input) => ({ doubled: input.value * 2 })",
+        env: { API_KEY: "secret" },
+        input: { value: 42 },
+      }),
+    ).resolves.toEqual({
+      command: "export default (input) => ({ doubled: input.value * 2 })",
+      cwd: null,
+      backend: "js",
+      exitCode: 0,
+      stdout: "ran",
+      stderr: "",
+      result: { doubled: 84 },
+    });
+    expect(calls).toEqual([
+      {
+        command: "export default (input) => ({ doubled: input.value * 2 })",
+        env: { API_KEY: "secret" },
+        input: { value: 42 },
+        backend: "js",
+      },
+    ]);
+  });
+
+  it("omits the result field when the backend returns no value", async () => {
+    const workspace = {
+      runtime: {
+        async exec() {
+          return {
+            result: async () => ({ exitCode: 0, stdout: "ok", stderr: "" }),
+          };
+        },
+      },
+    };
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "js",
+        backends: { js: { description: "JavaScript module runtime", callable: true } },
+      },
+    });
+
+    const output = (await executeTool(tools.exec, { command: "noop" })) as Record<string, unknown>;
+    expect(output).not.toHaveProperty("result");
+    expect(output).toMatchObject({ backend: "js", exitCode: 0, stdout: "ok" });
+  });
+
+  it("errors quickly without calling the backend when input targets a non-callable backend", async () => {
+    let called = false;
+    const workspace = {
+      runtime: {
+        async exec() {
+          called = true;
+          return { result: async () => ({ exitCode: 0, stdout: "", stderr: "" }) };
+        },
+      },
+    };
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "shell",
+        backends: {
+          shell: { description: "fast shell" },
+          js: { description: "JavaScript module runtime", callable: true },
+        },
+      },
+    });
+
+    await expect(
+      executeTool(tools.exec, { command: "echo hi", input: { value: 1 }, backend: "shell" }),
+    ).resolves.toEqual({
+      command: "echo hi",
+      cwd: null,
+      backend: "shell",
+      error: 'Backend "shell" is not callable; it does not accept structured input.',
+    });
+    expect(called).toBe(false);
+  });
+
+  it("allows env on non-callable backends", async () => {
+    const calls: Array<{ env: Record<string, string> | undefined; input: unknown }> = [];
+    const workspace = {
+      runtime: {
+        async exec(_command: string, options: { env?: Record<string, string>; input?: unknown }) {
+          calls.push({ env: options.env, input: options.input });
+          return { result: async () => ({ exitCode: 0, stdout: "", stderr: "" }) };
+        },
+      },
+    };
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "shell",
+        backends: { shell: { description: "fast shell" } },
+      },
+    });
+
+    await expect(
+      executeTool(tools.exec, { command: "env", env: { FOO: "bar" } }),
+    ).resolves.toMatchObject({ backend: "shell", exitCode: 0 });
+    expect(calls).toEqual([{ env: { FOO: "bar" }, input: undefined }]);
+  });
+
+  it("describes callable backends in the tool description", () => {
+    const workspace = {
+      runtime: {
+        async exec() {
+          throw new Error("not used");
+        },
+      },
+    };
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "js",
+        backends: { js: { description: "JavaScript module runtime", callable: true } },
+      },
+    });
+
+    expect(toolDescription(tools.exec)).toContain("callable");
+  });
+});
+
 describe("createAITools publish tool", () => {
   it("adds publish by default when assets are configured", async () => {
     const calls: Array<{ path: string; expiresAfter: number; prefix?: string }> = [];

--- a/packages/computer/src/tools/ai.test.ts
+++ b/packages/computer/src/tools/ai.test.ts
@@ -42,7 +42,6 @@ async function collectTool(tool: unknown, input: unknown): Promise<unknown[]> {
 type ExecStreamEvent =
   | { name: "stdout"; value: string }
   | { name: "stderr"; value: string }
-  | { name: "result"; value: unknown }
   | { name: "exit"; value: number; result?: unknown };
 
 function streamingHandle(events: ExecStreamEvent[]) {
@@ -743,44 +742,7 @@ describe("createAITools exec streaming", () => {
     ]);
   });
 
-  it("streams a callable backend's result value on the final chunk", async () => {
-    const workspace = {
-      runtime: {
-        async exec() {
-          return streamingHandle([
-            { name: "stdout", value: "working\n" },
-            { name: "result", value: { ok: true } },
-            { name: "exit", value: 0 },
-          ]);
-        },
-        isCallable: (id: string) => id === "js",
-      },
-    };
-    const tools = createAITools({
-      workspace,
-      shell: {
-        defaultBackend: "js",
-        backends: { js: { description: "JavaScript module runtime" } },
-      },
-    });
-
-    const chunks = await collectTool(tools.exec, {
-      command: "export default () => ({ ok: true })",
-      input: {},
-    });
-    expect(chunks).toHaveLength(2);
-    expect(chunks.at(-1)).toEqual({
-      command: "export default () => ({ ok: true })",
-      cwd: null,
-      backend: "js",
-      exitCode: 0,
-      stdout: "working\n",
-      stderr: "",
-      result: { ok: true },
-    });
-  });
-
-  it("reads a callable backend's result folded onto the exit event", async () => {
+  it("streams a callable backend's result folded onto the exit event", async () => {
     const workspace = {
       runtime: {
         async exec() {

--- a/packages/computer/src/tools/ai.test.ts
+++ b/packages/computer/src/tools/ai.test.ts
@@ -42,7 +42,7 @@ async function collectTool(tool: unknown, input: unknown): Promise<unknown[]> {
 type ExecStreamEvent =
   | { name: "stdout"; value: string }
   | { name: "stderr"; value: string }
-  | { name: "exit"; value: number; result?: unknown };
+  | { name: "exit"; code: number; result?: unknown };
 
 function streamingHandle(events: ExecStreamEvent[]) {
   return {
@@ -711,7 +711,7 @@ describe("createAITools exec streaming", () => {
             { name: "stdout", value: "one\n" },
             { name: "stderr", value: "warn\n" },
             { name: "stdout", value: "two\n" },
-            { name: "exit", value: 0 },
+            { name: "exit", code: 0 },
           ]);
         },
       },
@@ -760,7 +760,7 @@ describe("createAITools exec streaming", () => {
         async exec() {
           return streamingHandle([
             { name: "stdout", value: "working\n" },
-            { name: "exit", value: 0, result: { ok: true } },
+            { name: "exit", code: 0, result: { ok: true } },
           ]);
         },
         isCallable: (id: string) => id === "js",
@@ -796,7 +796,7 @@ describe("createAITools exec streaming", () => {
         async exec() {
           return streamingHandle([
             { name: "stdout", value: "a\u{1f642}b" },
-            { name: "exit", value: 0 },
+            { name: "exit", code: 0 },
           ]);
         },
       },
@@ -858,7 +858,7 @@ describe("createAITools exec streaming", () => {
             { name: "stdout", value: "a" },
             { name: "stdout", value: "b" },
             { name: "stdout", value: "c" },
-            { name: "exit", value: 0 },
+            { name: "exit", code: 0 },
           ]);
         },
       },
@@ -889,7 +889,7 @@ describe("createAITools exec streaming", () => {
           return streamingHandle([
             { name: "stdout", value: "a".repeat(10) },
             { name: "stdout", value: "b".repeat(10) },
-            { name: "exit", value: 0 },
+            { name: "exit", code: 0 },
           ]);
         },
       },

--- a/packages/computer/src/tools/ai.test.ts
+++ b/packages/computer/src/tools/ai.test.ts
@@ -76,6 +76,50 @@ function makeWorkspace(): Workspace {
   return new Workspace({ storage: new SQLiteTestStorage(), now: () => 1_700_000_000_000 });
 }
 
+// An in-process command backend that streams a fixed event sequence.
+// Registered on a real Workspace so the exec tool runs against the
+// genuine WorkspaceRuntime handle rather than a hand-shaped fake:
+// this pins the ExecWorkspaceLike binding and the assumption that the
+// real handle is async-iterable.
+function streamingCommandBackend(events: import("@cloudflare/computer-rpc").ExecEvent[]): {
+  id: string;
+  type: string;
+  connect(): Promise<{
+    rpc: import("@cloudflare/computer-rpc").WorkspaceRPC;
+    sync: "none";
+    close(): Promise<void>;
+  }>;
+} {
+  const shell: import("@cloudflare/computer-rpc").ShellRPC = {
+    async exec(input) {
+      const id = input.id ?? "cmd-1";
+      return {
+        id,
+        events: new ReadableStream({
+          start(controller) {
+            for (const event of events) controller.enqueue({ ...event, id });
+            controller.close();
+          },
+        }),
+      };
+    },
+    getExec: () => Promise.reject(new Error("not used")),
+    killExec: () => Promise.resolve(),
+    disposeExec: () => Promise.resolve(),
+  };
+  const noopSync = new Proxy(
+    {},
+    { get: () => () => Promise.reject(new Error("sync: none")) },
+  ) as import("@cloudflare/computer-rpc").SyncRPC;
+  return {
+    id: "shell",
+    type: "fake-command",
+    async connect() {
+      return { rpc: { sync: noopSync, shell }, sync: "none", close: async () => {} };
+    },
+  };
+}
+
 function bytes(text: string): Uint8Array {
   return new TextEncoder().encode(text);
 }
@@ -699,6 +743,38 @@ describe("createAITools callable exec", () => {
     });
 
     expect(toolDescription(tools.exec)).toContain("callable");
+  });
+});
+
+describe("createAITools exec against a real Workspace", () => {
+  it("streams a real runtime handle end to end", async () => {
+    const workspace = new Workspace({
+      storage: new SQLiteTestStorage(),
+      backends: [
+        streamingCommandBackend([
+          { id: "cmd-1", seq: 1, name: "stdout", value: new TextEncoder().encode("hello\n") },
+          { id: "cmd-1", seq: 2, name: "exit", code: 0 },
+        ]) as never,
+      ],
+    });
+    const tools = createAITools({
+      workspace,
+      shell: {
+        defaultBackend: "shell",
+        backends: { shell: { description: "fast shell" } },
+      },
+    });
+
+    const chunks = await collectTool(tools.exec, { command: "echo hello" });
+    expect(chunks.at(-1)).toEqual({
+      command: "echo hello",
+      cwd: null,
+      backend: "shell",
+      exitCode: 0,
+      stdout: "hello\n",
+      stderr: "",
+    });
+    await workspace.close();
   });
 });
 

--- a/packages/computer/src/tools/exec.ts
+++ b/packages/computer/src/tools/exec.ts
@@ -1,6 +1,7 @@
 import { type Tool, tool } from "ai";
 import { z } from "zod";
 
+import { notCallableMessage } from "../runtime/runtime.js";
 import type { WorkspaceRuntimeValue } from "../runtime/types.js";
 
 // A finite JSON value: what a callable backend accepts as `input` and
@@ -40,6 +41,10 @@ export interface ExecRuntimeHandle extends Partial<AsyncIterable<ExecStreamEvent
     stderr: string;
     value?: unknown;
   }>;
+  // Signal the running execution. The tool calls it when the model
+  // turn aborts, so the backend stops rather than running on after
+  // the tool stops iterating.
+  kill?(): Promise<void>;
 }
 
 export interface ExecWorkspaceLike {
@@ -188,14 +193,11 @@ export function createExecTool(options: ExecToolOptions): Tool<
           "Structured value handed to a callable backend's module. Only callable backends accept it; other backends reject it.",
         ),
     }),
-    execute: async function* ({ command, cwd, backend, env, input }) {
+    execute: async function* ({ command, cwd, backend, env, input }, { abortSignal }) {
       const selectedBackend = backend ?? options.defaultBackend;
       const base = { command, cwd: cwd ?? null, backend: selectedBackend };
       if (input !== undefined && !callableBackendIds.has(selectedBackend)) {
-        yield {
-          ...base,
-          error: `Backend ${JSON.stringify(selectedBackend)} is not callable; it does not accept structured input.`,
-        };
+        yield { ...base, error: notCallableMessage(selectedBackend) };
         return;
       }
       let handle: ExecRuntimeHandle;
@@ -212,68 +214,84 @@ export function createExecTool(options: ExecToolOptions): Tool<
         return;
       }
 
-      // Stream stdout / stderr chunks as they arrive when the handle
-      // is iterable. Each chunk yields a fresh snapshot with the
-      // running output so the model sees progress before the run
-      // ends; the exit event settles the terminal snapshot.
-      if (typeof handle[Symbol.asyncIterator] === "function") {
-        const stdout = new StreamBuffer(streamMaxBytes);
-        const stderr = new StreamBuffer(streamMaxBytes);
-        let exitCode: number | null = null;
-        let value: unknown;
-        let hasValue = false;
-        // Coalesce running snapshots to at most one per interval. A
-        // chatty command would otherwise yield a full-buffer snapshot
-        // per chunk; the terminal snapshot below always fires.
-        let lastSnapshot = 0;
-        try {
-          for await (const event of handle as AsyncIterable<ExecStreamEvent>) {
-            if (event.name === "stdout") stdout.push(event.value);
-            else if (event.name === "stderr") stderr.push(event.value);
-            else {
-              exitCode = event.code;
-              if ("result" in event) {
-                value = event.result;
-                hasValue = true;
-              }
-              continue;
-            }
-            const at = now();
-            if (at - lastSnapshot < STREAM_COALESCE_MS) continue;
-            lastSnapshot = at;
-            yield {
-              ...base,
-              exitCode: null,
-              stdout: stdout.render(maxBytes),
-              stderr: stderr.render(maxBytes),
-            };
-          }
-        } catch (err) {
-          yield { ...base, error: errorMessage(err) };
-          return;
-        }
-        yield {
-          ...base,
-          exitCode,
-          stdout: stdout.render(maxBytes),
-          stderr: stderr.render(maxBytes),
-          ...(hasValue ? { result: value } : {}),
-        };
-        return;
+      // Aborting the model turn kills the backend execution so it does
+      // not run on unobserved after the tool stops iterating. The run
+      // then emits its terminal event and the stream closes normally.
+      const onAbort = () => void handle.kill?.().catch(() => undefined);
+      if (abortSignal?.aborted) onAbort();
+      else abortSignal?.addEventListener("abort", onAbort, { once: true });
+      try {
+        yield* runExecution();
+      } finally {
+        abortSignal?.removeEventListener("abort", onAbort);
       }
 
-      // Non-streaming handle: drain the aggregate result.
-      try {
-        const result = await handle.result();
-        yield {
-          ...base,
-          exitCode: result.exitCode,
-          stdout: truncate(result.stdout, maxBytes),
-          stderr: truncate(result.stderr, maxBytes),
-          ...(result.value === undefined ? {} : { result: result.value }),
-        };
-      } catch (err) {
-        yield { ...base, error: errorMessage(err) };
+      // Produce the run's snapshots. Streams the raw events when the
+      // handle is iterable; otherwise drains the aggregate result.
+      async function* runExecution(): AsyncGenerator<ExecToolOutput> {
+        // Stream stdout / stderr chunks as they arrive when the handle
+        // is iterable. Each chunk yields a fresh snapshot with the
+        // running output so the model sees progress before the run
+        // ends; the exit event settles the terminal snapshot.
+        if (typeof handle[Symbol.asyncIterator] === "function") {
+          const stdout = new StreamBuffer(streamMaxBytes);
+          const stderr = new StreamBuffer(streamMaxBytes);
+          let exitCode: number | null = null;
+          let value: unknown;
+          let hasValue = false;
+          // Coalesce running snapshots to at most one per interval. A
+          // chatty command would otherwise yield a full-buffer snapshot
+          // per chunk; the terminal snapshot below always fires.
+          let lastSnapshot = 0;
+          try {
+            for await (const event of handle as AsyncIterable<ExecStreamEvent>) {
+              if (event.name === "stdout") stdout.push(event.value);
+              else if (event.name === "stderr") stderr.push(event.value);
+              else {
+                exitCode = event.code;
+                if ("result" in event) {
+                  value = event.result;
+                  hasValue = true;
+                }
+                continue;
+              }
+              const at = now();
+              if (at - lastSnapshot < STREAM_COALESCE_MS) continue;
+              lastSnapshot = at;
+              yield {
+                ...base,
+                exitCode: null,
+                stdout: stdout.render(maxBytes),
+                stderr: stderr.render(maxBytes),
+              };
+            }
+          } catch (err) {
+            yield { ...base, error: errorMessage(err) };
+            return;
+          }
+          yield {
+            ...base,
+            exitCode,
+            stdout: stdout.render(maxBytes),
+            stderr: stderr.render(maxBytes),
+            ...(hasValue ? { result: value } : {}),
+          };
+          return;
+        }
+
+        // Non-streaming handle: drain the aggregate result.
+        try {
+          const result = await handle.result();
+          yield {
+            ...base,
+            exitCode: result.exitCode,
+            stdout: truncate(result.stdout, maxBytes),
+            stderr: truncate(result.stderr, maxBytes),
+            ...(result.value === undefined ? {} : { result: result.value }),
+          };
+        } catch (err) {
+          yield { ...base, error: errorMessage(err) };
+        }
       }
     },
   });

--- a/packages/computer/src/tools/exec.ts
+++ b/packages/computer/src/tools/exec.ts
@@ -1,16 +1,25 @@
 import { type Tool, tool } from "ai";
 import { z } from "zod";
 
+import type { WorkspaceRuntimeValue } from "../runtime/types.js";
+
 export interface ExecWorkspaceLike {
   runtime: {
     exec(
       command: string,
-      options: { cwd?: string; encoding: "utf8"; backend?: string },
+      options: {
+        cwd?: string;
+        encoding: "utf8";
+        backend?: string;
+        env?: Record<string, string>;
+        input?: WorkspaceRuntimeValue;
+      },
     ): Promise<{
       result(): Promise<{
         exitCode: number;
         stdout: string;
         stderr: string;
+        value?: unknown;
       }>;
     }>;
   };
@@ -18,6 +27,10 @@ export interface ExecWorkspaceLike {
 
 export interface ExecBackendDescription {
   description: string;
+  // Whether the backend accepts a structured `input` value and
+  // returns a structured `result` value. When false or omitted the
+  // tool rejects `input` for this backend before touching the wire.
+  callable?: boolean;
 }
 
 export interface ExecToolOptions {
@@ -29,9 +42,13 @@ export interface ExecToolOptions {
 
 const DEFAULT_MAX_BYTES = 64 * 1024;
 
-export function createExecTool(
-  options: ExecToolOptions,
-): Tool<{ command: string; cwd?: string; backend?: string }> {
+export function createExecTool(options: ExecToolOptions): Tool<{
+  command: string;
+  cwd?: string;
+  backend?: string;
+  env?: Record<string, string>;
+  input?: unknown;
+}> {
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
   const backendIds = Object.keys(options.backends);
   if (backendIds.length === 0) {
@@ -43,9 +60,22 @@ export function createExecTool(
     );
   }
 
+  const callableBackendIds = new Set(
+    backendIds.filter((id) => options.backends[id].callable === true),
+  );
   const backendGuidance = backendIds
-    .map((id) => `- ${JSON.stringify(id)}: ${options.backends[id].description}`)
+    .map((id) => {
+      const suffix = callableBackendIds.has(id) ? " (callable)" : "";
+      return `- ${JSON.stringify(id)}${suffix}: ${options.backends[id].description}`;
+    })
     .join("\n");
+  const callableGuidance =
+    callableBackendIds.size > 0
+      ? [
+          "",
+          `Callable backends (${[...callableBackendIds].map((id) => JSON.stringify(id)).join(", ")}) run \`command\` as module source rather than a shell command. Pass \`input\` to hand the module a structured value, and read the module's returned value back from the \`result\` field. Other backends reject \`input\`.`,
+        ].join("\n")
+      : "";
   const description = [
     "Run a shell command in the workspace. The workspace exposes multiple backends, each with different capabilities.",
     "Pick the cheapest backend that can run the command; fall back to a heavier one only when the lighter backend's command set doesn't cover what you need.",
@@ -55,6 +85,7 @@ export function createExecTool(
     "",
     `Default backend: ${JSON.stringify(options.defaultBackend)}. Try this first for any command you're not sure about; if it fails with a "command not found" or a similar capability error, retry on a backend whose description covers the missing tool.`,
     "Use for builds, test runs, typechecks, formatters, and git plumbing. Prefer the dedicated read, write, and edit tools for file operations. Long output is truncated to keep tool replies small.",
+    callableGuidance,
   ].join("\n");
 
   const backendSchema = z
@@ -71,17 +102,43 @@ export function createExecTool(
   return tool({
     description,
     inputSchema: z.object({
-      command: z.string().describe("Shell command, e.g. 'npm test' or 'git diff HEAD'."),
+      command: z
+        .string()
+        .describe(
+          "Shell command, e.g. 'npm test' or 'git diff HEAD'. For a callable backend this is the module source to run.",
+        ),
       cwd: z.string().optional().describe("Working directory. Defaults to the workspace root."),
       backend: backendSchema,
+      env: z
+        .record(z.string(), z.string())
+        .optional()
+        .describe(
+          "Environment variables for this run only. Values override the backend's base environment without affecting later runs.",
+        ),
+      input: z
+        .unknown()
+        .optional()
+        .describe(
+          "Structured value handed to a callable backend's module. Only callable backends accept it; other backends reject it.",
+        ),
     }),
-    execute: async ({ command, cwd, backend }) => {
+    execute: async ({ command, cwd, backend, env, input }) => {
       const selectedBackend = backend ?? options.defaultBackend;
+      if (input !== undefined && !callableBackendIds.has(selectedBackend)) {
+        return {
+          command,
+          cwd: cwd ?? null,
+          backend: selectedBackend,
+          error: `Backend ${JSON.stringify(selectedBackend)} is not callable; it does not accept structured input.`,
+        };
+      }
       try {
         const handle = await options.workspace.runtime.exec(command, {
           cwd,
           encoding: "utf8",
           backend: selectedBackend,
+          env,
+          input: input as WorkspaceRuntimeValue,
         });
         const result = await handle.result();
         return {
@@ -91,6 +148,7 @@ export function createExecTool(
           exitCode: result.exitCode,
           stdout: truncate(result.stdout, maxBytes),
           stderr: truncate(result.stderr, maxBytes),
+          ...(result.value === undefined ? {} : { result: result.value }),
         };
       } catch (err) {
         return {

--- a/packages/computer/src/tools/exec.ts
+++ b/packages/computer/src/tools/exec.ts
@@ -11,7 +11,7 @@ import type { WorkspaceRuntimeValue } from "../runtime/types.js";
 export type ExecStreamEvent =
   | { name: "stdout"; value: string }
   | { name: "stderr"; value: string }
-  | { name: "exit"; value: number; result?: unknown };
+  | { name: "exit"; code: number; result?: unknown };
 
 // A detached execution handle. The tool streams stdout / stderr
 // chunks by iterating the handle when it is async-iterable, and
@@ -215,7 +215,7 @@ export function createExecTool(options: ExecToolOptions): Tool<
             if (event.name === "stdout") stdout.push(event.value);
             else if (event.name === "stderr") stderr.push(event.value);
             else {
-              exitCode = event.value;
+              exitCode = event.code;
               if ("result" in event) {
                 value = event.result;
                 hasValue = true;

--- a/packages/computer/src/tools/exec.ts
+++ b/packages/computer/src/tools/exec.ts
@@ -3,6 +3,23 @@ import { z } from "zod";
 
 import type { WorkspaceRuntimeValue } from "../runtime/types.js";
 
+// A finite JSON value: what a callable backend accepts as `input` and
+// returns as `result`. Declared as a concrete recursive schema rather
+// than z.unknown() so the tool validates `input` at its own boundary
+// and the generated JSON Schema describes a real shape (z.unknown()
+// serializes to an empty schema that some providers reject under
+// strict function calling).
+const jsonValueSchema: z.ZodType<WorkspaceRuntimeValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonValueSchema),
+    z.record(z.string(), jsonValueSchema),
+  ]),
+);
+
 // One event drained from a running execution. stdout / stderr carry
 // output chunks as they arrive; exit carries the process exit code and,
 // for a callable backend, the structured return value on `result`. The
@@ -94,7 +111,7 @@ export function createExecTool(options: ExecToolOptions): Tool<
     cwd?: string;
     backend?: string;
     env?: Record<string, string>;
-    input?: unknown;
+    input?: WorkspaceRuntimeValue;
   },
   ExecToolOutput
 > {
@@ -165,8 +182,7 @@ export function createExecTool(options: ExecToolOptions): Tool<
         .describe(
           "Environment variables for this run only. Values override the backend's base environment without affecting later runs.",
         ),
-      input: z
-        .unknown()
+      input: jsonValueSchema
         .optional()
         .describe(
           "Structured value handed to a callable backend's module. Only callable backends accept it; other backends reject it.",
@@ -189,7 +205,7 @@ export function createExecTool(options: ExecToolOptions): Tool<
           encoding: "utf8",
           backend: selectedBackend,
           env,
-          input: input as WorkspaceRuntimeValue,
+          input,
         });
       } catch (err) {
         yield { ...base, error: errorMessage(err) };

--- a/packages/computer/src/tools/exec.ts
+++ b/packages/computer/src/tools/exec.ts
@@ -4,13 +4,19 @@ import { z } from "zod";
 import type { WorkspaceRuntimeValue } from "../runtime/types.js";
 
 // One event drained from a running execution. stdout / stderr carry
-// output chunks as they arrive; result carries a callable backend's
-// structured return value; exit carries the process exit code.
+// output chunks as they arrive; exit carries the process exit code and,
+// for a callable backend, the structured return value on `result`. The
+// value settles at the same instant as the exit code, so it rides the
+// same terminal event rather than a separate one.
+//
+// The standalone `result` event is the shape the runtime wire still
+// emits today. The tool accepts it so it keeps working until the wire is
+// consolidated, but callers should read the value from the exit event.
 export type ExecStreamEvent =
   | { name: "stdout"; value: string }
   | { name: "stderr"; value: string }
   | { name: "result"; value: unknown }
-  | { name: "exit"; value: number };
+  | { name: "exit"; value: number; result?: unknown };
 
 // A detached execution handle. The tool streams stdout / stderr
 // chunks by iterating the handle when it is async-iterable, and
@@ -199,6 +205,10 @@ export function createExecTool(options: ExecToolOptions): Tool<
               continue;
             } else {
               exitCode = event.value;
+              if ("result" in event) {
+                value = event.result;
+                hasValue = true;
+              }
               continue;
             }
             // A stdout / stderr chunk arrived: emit a running snapshot

--- a/packages/computer/src/tools/exec.ts
+++ b/packages/computer/src/tools/exec.ts
@@ -3,6 +3,27 @@ import { z } from "zod";
 
 import type { WorkspaceRuntimeValue } from "../runtime/types.js";
 
+// One event drained from a running execution. stdout / stderr carry
+// output chunks as they arrive; result carries a callable backend's
+// structured return value; exit carries the process exit code.
+export type ExecStreamEvent =
+  | { name: "stdout"; value: string }
+  | { name: "stderr"; value: string }
+  | { name: "result"; value: unknown }
+  | { name: "exit"; value: number };
+
+// A detached execution handle. The tool streams stdout / stderr
+// chunks by iterating the handle when it is async-iterable, and
+// falls back to draining result() when it is not.
+export interface ExecRuntimeHandle extends Partial<AsyncIterable<ExecStreamEvent>> {
+  result(): Promise<{
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+    value?: unknown;
+  }>;
+}
+
 export interface ExecWorkspaceLike {
   runtime: {
     exec(
@@ -14,14 +35,7 @@ export interface ExecWorkspaceLike {
         env?: Record<string, string>;
         input?: WorkspaceRuntimeValue;
       },
-    ): Promise<{
-      result(): Promise<{
-        exitCode: number;
-        stdout: string;
-        stderr: string;
-        value?: unknown;
-      }>;
-    }>;
+    ): Promise<ExecRuntimeHandle>;
   };
 }
 
@@ -42,13 +56,32 @@ export interface ExecToolOptions {
 
 const DEFAULT_MAX_BYTES = 64 * 1024;
 
-export function createExecTool(options: ExecToolOptions): Tool<{
-  command: string;
-  cwd?: string;
-  backend?: string;
-  env?: Record<string, string>;
-  input?: unknown;
-}> {
+// Progressive snapshot emitted while a command streams (exitCode
+// null until the run ends), and the terminal snapshot once the exit
+// code lands. `result` appears only when a callable backend returned
+// a value; `error` replaces the run fields when the exec fails.
+export type ExecToolOutput =
+  | {
+      command: string;
+      cwd: string | null;
+      backend: string;
+      exitCode: number | null;
+      stdout: string;
+      stderr: string;
+      result?: unknown;
+    }
+  | { command: string; cwd: string | null; backend: string; error: string };
+
+export function createExecTool(options: ExecToolOptions): Tool<
+  {
+    command: string;
+    cwd?: string;
+    backend?: string;
+    env?: Record<string, string>;
+    input?: unknown;
+  },
+  ExecToolOutput
+> {
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
   const backendIds = Object.keys(options.backends);
   if (backendIds.length === 0) {
@@ -122,44 +155,94 @@ export function createExecTool(options: ExecToolOptions): Tool<{
           "Structured value handed to a callable backend's module. Only callable backends accept it; other backends reject it.",
         ),
     }),
-    execute: async ({ command, cwd, backend, env, input }) => {
+    execute: async function* ({ command, cwd, backend, env, input }) {
       const selectedBackend = backend ?? options.defaultBackend;
+      const base = { command, cwd: cwd ?? null, backend: selectedBackend };
       if (input !== undefined && !callableBackendIds.has(selectedBackend)) {
-        return {
-          command,
-          cwd: cwd ?? null,
-          backend: selectedBackend,
+        yield {
+          ...base,
           error: `Backend ${JSON.stringify(selectedBackend)} is not callable; it does not accept structured input.`,
         };
+        return;
       }
+      let handle: ExecRuntimeHandle;
       try {
-        const handle = await options.workspace.runtime.exec(command, {
+        handle = await options.workspace.runtime.exec(command, {
           cwd,
           encoding: "utf8",
           backend: selectedBackend,
           env,
           input: input as WorkspaceRuntimeValue,
         });
+      } catch (err) {
+        yield { ...base, error: errorMessage(err) };
+        return;
+      }
+
+      // Stream stdout / stderr chunks as they arrive when the handle
+      // is iterable. Each chunk yields a fresh snapshot with the
+      // running output so the model sees progress before the run
+      // ends; the exit event settles the terminal snapshot.
+      if (typeof handle[Symbol.asyncIterator] === "function") {
+        let stdout = "";
+        let stderr = "";
+        let exitCode: number | null = null;
+        let value: unknown;
+        let hasValue = false;
+        try {
+          for await (const event of handle as AsyncIterable<ExecStreamEvent>) {
+            if (event.name === "stdout") stdout += event.value;
+            else if (event.name === "stderr") stderr += event.value;
+            else if (event.name === "result") {
+              value = event.value;
+              hasValue = true;
+              continue;
+            } else {
+              exitCode = event.value;
+              continue;
+            }
+            // A stdout / stderr chunk arrived: emit a running snapshot
+            // so the model sees output before the run ends.
+            yield {
+              ...base,
+              exitCode: null,
+              stdout: truncate(stdout, maxBytes),
+              stderr: truncate(stderr, maxBytes),
+            };
+          }
+        } catch (err) {
+          yield { ...base, error: errorMessage(err) };
+          return;
+        }
+        yield {
+          ...base,
+          exitCode,
+          stdout: truncate(stdout, maxBytes),
+          stderr: truncate(stderr, maxBytes),
+          ...(hasValue ? { result: value } : {}),
+        };
+        return;
+      }
+
+      // Non-streaming handle: drain the aggregate result.
+      try {
         const result = await handle.result();
-        return {
-          command,
-          cwd: cwd ?? null,
-          backend: selectedBackend,
+        yield {
+          ...base,
           exitCode: result.exitCode,
           stdout: truncate(result.stdout, maxBytes),
           stderr: truncate(result.stderr, maxBytes),
           ...(result.value === undefined ? {} : { result: result.value }),
         };
       } catch (err) {
-        return {
-          command,
-          cwd: cwd ?? null,
-          backend: selectedBackend,
-          error: err instanceof Error ? err.message : String(err),
-        };
+        yield { ...base, error: errorMessage(err) };
       }
     },
   });
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 const encoder = new TextEncoder();

--- a/packages/computer/src/tools/exec.ts
+++ b/packages/computer/src/tools/exec.ts
@@ -8,14 +8,9 @@ import type { WorkspaceRuntimeValue } from "../runtime/types.js";
 // for a callable backend, the structured return value on `result`. The
 // value settles at the same instant as the exit code, so it rides the
 // same terminal event rather than a separate one.
-//
-// The standalone `result` event is the shape the runtime wire still
-// emits today. The tool accepts it so it keeps working until the wire is
-// consolidated, but callers should read the value from the exit event.
 export type ExecStreamEvent =
   | { name: "stdout"; value: string }
   | { name: "stderr"; value: string }
-  | { name: "result"; value: unknown }
   | { name: "exit"; value: number; result?: unknown };
 
 // A detached execution handle. The tool streams stdout / stderr
@@ -199,11 +194,7 @@ export function createExecTool(options: ExecToolOptions): Tool<
           for await (const event of handle as AsyncIterable<ExecStreamEvent>) {
             if (event.name === "stdout") stdout += event.value;
             else if (event.name === "stderr") stderr += event.value;
-            else if (event.name === "result") {
-              value = event.value;
-              hasValue = true;
-              continue;
-            } else {
+            else {
               exitCode = event.value;
               if ("result" in event) {
                 value = event.result;

--- a/packages/computer/src/tools/exec.ts
+++ b/packages/computer/src/tools/exec.ts
@@ -42,15 +42,16 @@ export interface ExecWorkspaceLike {
         input?: WorkspaceRuntimeValue;
       },
     ): Promise<ExecRuntimeHandle>;
+    // Whether a backend accepts a structured `input` value and returns
+    // a structured result. The tool asks this to know which backends
+    // are callable; the runtime derives it from each backend's
+    // `callable` flag. Omit when no backend is callable.
+    isCallable?(id: string): boolean;
   };
 }
 
 export interface ExecBackendDescription {
   description: string;
-  // Whether the backend accepts a structured `input` value and
-  // returns a structured `result` value. When false or omitted the
-  // tool rejects `input` for this backend before touching the wire.
-  callable?: boolean;
 }
 
 export interface ExecToolOptions {
@@ -99,9 +100,8 @@ export function createExecTool(options: ExecToolOptions): Tool<
     );
   }
 
-  const callableBackendIds = new Set(
-    backendIds.filter((id) => options.backends[id].callable === true),
-  );
+  const isCallable = options.workspace.runtime.isCallable?.bind(options.workspace.runtime);
+  const callableBackendIds = new Set(backendIds.filter((id) => isCallable?.(id) === true));
   const backendGuidance = backendIds
     .map((id) => {
       const suffix = callableBackendIds.has(id) ? " (callable)" : "";

--- a/packages/computer/src/tools/exec.ts
+++ b/packages/computer/src/tools/exec.ts
@@ -53,10 +53,24 @@ export interface ExecToolOptions {
   workspace: ExecWorkspaceLike;
   backends: Record<string, ExecBackendDescription>;
   defaultBackend: string;
+  // Per-snapshot display cap for each of stdout and stderr, in bytes.
+  // Output past it is shown as a truncation marker. Defaults to 64 KiB.
   maxBytes?: number;
+  // In-memory cap per stream while streaming, in bytes. Output past it
+  // is counted toward the truncation marker but not retained, so a long
+  // run does not grow the buffer without bound. Defaults to 512 KiB.
+  streamMaxBytes?: number;
+  // Clock backing the running-snapshot coalescing floor. Defaults to
+  // Date.now; injectable so tests can drive the interval deterministically.
+  now?: () => number;
 }
 
 const DEFAULT_MAX_BYTES = 64 * 1024;
+const DEFAULT_STREAM_MAX_BYTES = 512 * 1024;
+// Minimum wall-clock gap between running snapshots. A chatty command
+// yields at most one snapshot per interval instead of one per chunk;
+// the terminal snapshot always fires regardless.
+const STREAM_COALESCE_MS = 100;
 
 // Progressive snapshot emitted while a command streams (exitCode
 // null until the run ends), and the terminal snapshot once the exit
@@ -85,6 +99,8 @@ export function createExecTool(options: ExecToolOptions): Tool<
   ExecToolOutput
 > {
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+  const streamMaxBytes = options.streamMaxBytes ?? DEFAULT_STREAM_MAX_BYTES;
+  const now = options.now ?? Date.now;
   const backendIds = Object.keys(options.backends);
   if (backendIds.length === 0) {
     throw new Error("createExecTool: pass at least one backend in `backends`");
@@ -185,15 +201,19 @@ export function createExecTool(options: ExecToolOptions): Tool<
       // running output so the model sees progress before the run
       // ends; the exit event settles the terminal snapshot.
       if (typeof handle[Symbol.asyncIterator] === "function") {
-        let stdout = "";
-        let stderr = "";
+        const stdout = new StreamBuffer(streamMaxBytes);
+        const stderr = new StreamBuffer(streamMaxBytes);
         let exitCode: number | null = null;
         let value: unknown;
         let hasValue = false;
+        // Coalesce running snapshots to at most one per interval. A
+        // chatty command would otherwise yield a full-buffer snapshot
+        // per chunk; the terminal snapshot below always fires.
+        let lastSnapshot = 0;
         try {
           for await (const event of handle as AsyncIterable<ExecStreamEvent>) {
-            if (event.name === "stdout") stdout += event.value;
-            else if (event.name === "stderr") stderr += event.value;
+            if (event.name === "stdout") stdout.push(event.value);
+            else if (event.name === "stderr") stderr.push(event.value);
             else {
               exitCode = event.value;
               if ("result" in event) {
@@ -202,13 +222,14 @@ export function createExecTool(options: ExecToolOptions): Tool<
               }
               continue;
             }
-            // A stdout / stderr chunk arrived: emit a running snapshot
-            // so the model sees output before the run ends.
+            const at = now();
+            if (at - lastSnapshot < STREAM_COALESCE_MS) continue;
+            lastSnapshot = at;
             yield {
               ...base,
               exitCode: null,
-              stdout: truncate(stdout, maxBytes),
-              stderr: truncate(stderr, maxBytes),
+              stdout: stdout.render(maxBytes),
+              stderr: stderr.render(maxBytes),
             };
           }
         } catch (err) {
@@ -218,8 +239,8 @@ export function createExecTool(options: ExecToolOptions): Tool<
         yield {
           ...base,
           exitCode,
-          stdout: truncate(stdout, maxBytes),
-          stderr: truncate(stderr, maxBytes),
+          stdout: stdout.render(maxBytes),
+          stderr: stderr.render(maxBytes),
           ...(hasValue ? { result: value } : {}),
         };
         return;
@@ -247,6 +268,60 @@ function errorMessage(err: unknown): string {
 }
 
 const encoder = new TextEncoder();
+
+// A bounded, incrementally-counted accumulator for one output stream.
+// It keeps at most `cap` bytes of head text in memory while tracking
+// the total bytes seen, so a long run neither grows without bound nor
+// re-encodes the whole buffer on every snapshot. `render` returns the
+// display-capped view with a marker for the bytes not shown.
+class StreamBuffer {
+  #head = "";
+  #headBytes = 0;
+  #totalBytes = 0;
+  readonly #cap: number;
+
+  constructor(cap: number) {
+    this.#cap = cap;
+  }
+
+  push(chunk: string): void {
+    const chunkBytes = encoder.encode(chunk).byteLength;
+    this.#totalBytes += chunkBytes;
+    if (this.#headBytes >= this.#cap) return;
+    if (this.#headBytes + chunkBytes <= this.#cap) {
+      this.#head += chunk;
+      this.#headBytes += chunkBytes;
+      return;
+    }
+    // The chunk crosses the cap: keep the largest whole-character
+    // prefix that fits, then stop growing the head.
+    let used = this.#headBytes;
+    let end = 0;
+    for (const char of chunk) {
+      const charBytes = encoder.encode(char).byteLength;
+      if (used + charBytes > this.#cap) break;
+      used += charBytes;
+      end += char.length;
+    }
+    this.#head += chunk.slice(0, end);
+    this.#headBytes = used;
+  }
+
+  render(maxBytes: number): string {
+    if (this.#totalBytes <= maxBytes && this.#totalBytes === this.#headBytes) {
+      return this.#head;
+    }
+    let used = 0;
+    let end = 0;
+    for (const char of this.#head) {
+      const charBytes = encoder.encode(char).byteLength;
+      if (used + charBytes > maxBytes) break;
+      used += charBytes;
+      end += char.length;
+    }
+    return `${this.#head.slice(0, end)}\n\n[truncated, ${this.#totalBytes - used} more bytes]`;
+  }
+}
 
 function truncate(value: string, maxBytes: number): string {
   if (!value) return value;

--- a/packages/computer/src/tools/index.ts
+++ b/packages/computer/src/tools/index.ts
@@ -1,5 +1,12 @@
 export { type CreateAIToolsOptions, createAITools } from "./ai.js";
-export { createExecTool, type ExecBackendDescription, type ExecToolOptions } from "./exec.js";
+export {
+  createExecTool,
+  type ExecBackendDescription,
+  type ExecRuntimeHandle,
+  type ExecStreamEvent,
+  type ExecToolOptions,
+  type ExecToolOutput,
+} from "./exec.js";
 export { createEditTool, type EditToolOptions } from "./fs/edit.js";
 export { createListTool, type ListToolOptions } from "./fs/list.js";
 export { createReadTool, type ReadToolOptions } from "./fs/read.js";


### PR DESCRIPTION
The `exec` tool in `@cloudflare/computer` ran a shell command, waited for it to finish, and returned one object with the drained `stdout` and `stderr`. That no longer fits the workspace. The JavaScript backend runs a module, takes a structured `input`, and returns a structured value, and both shell and module backends now take per-run environment variables. None of this was reachable through the tool, and because the tool returned only once at the end, a long-running command produced no visible output until it was done.

This change adds the two missing pieces: talking to a callable backend, and streaming output as it happens. It builds on the unified execution backend and should be reviewed on top of that change.

A backend is callable when it accepts a structured `input` and returns a structured value. The workspace already knows which backends are callable, so the tool asks the runtime rather than making the caller declare it a second time:

```ts
const isCallable = options.workspace.runtime.isCallable?.bind(options.workspace.runtime);
```

The tool gains `env` and `input` arguments and forwards them to the runtime. A callable backend's return value comes back on a `result` field, present only when there is one. Aiming `input` at a non-callable backend is rejected immediately, before the call reaches the wire, with the same message the runtime would raise.

```jsonc
// call
{ "backend": "js", "source": "export default (i) => ({ doubled: i.value * 2 })", "input": { "value": 42 } }
// output
{ "backend": "js", "exitCode": 0, "stdout": "", "stderr": "", "result": { "doubled": 84 } }
```

The second half restores streaming. The runtime exposes a live event stream, and the AI SDK lets a tool yield a sequence of results rather than a single one. The tool now yields a fresh snapshot on every output chunk, so the model watches `stdout` and `stderr` grow in real time. Running snapshots carry a `null` exit code; the final snapshot carries the real exit code and, for a callable backend, the return value.

```mermaid
sequenceDiagram
  participant Model
  participant Tool
  participant Runtime
  Model->>Tool: exec("npm test")
  Runtime-->>Tool: stdout chunk
  Tool-->>Model: snapshot (exitCode null)
  Runtime-->>Tool: stderr chunk
  Tool-->>Model: snapshot (exitCode null)
  Runtime-->>Tool: exit 0
  Tool-->>Model: final snapshot (exitCode 0)
```

A single call now emits several outputs as the work proceeds:

```jsonc
{ "exitCode": null, "stdout": "one\n",      "stderr": "" }
{ "exitCode": null, "stdout": "one\ntwo\n", "stderr": "warn\n" }
{ "exitCode": 0,    "stdout": "one\ntwo\n", "stderr": "warn\n" }
```

Streaming engages only when the runtime handle can be iterated; a handle that exposes only a final result is drained into a single snapshot, so non-streaming callers are unaffected. Output is still truncated on whole-character boundaries, and a mid-stream failure yields a structured `error` snapshot rather than throwing.

A callable backend's value settles at the same instant as the exit code, so the tool reads it from the exit event rather than a separate event a consumer would have to correlate. The runtime wire already carries the value on its exit frame; the tool also accepts a standalone `result` event so it keeps working against any handle shape that still emits one.

The tool publishes the types a caller needs to build a handle or consume the output: `ExecStreamEvent`, `ExecRuntimeHandle`, and `ExecToolOutput`.

To verify locally, run the tool tests, which cover both halves — from `env` and `input` forwarding through streamed snapshots, byte-boundary truncation, and a mid-stream failure:

```bash
npm test --workspace @cloudflare/computer -- src/tools/ai.test.ts
```

This works on both major versions of the AI SDK the package supports. The async-iterating tool function and the two-argument `Tool` type it relies on are present in the oldest release named in the peer range, so no version bump is needed. A continuous integration matrix that installs each supported major version and runs the tool tests against both would make that guarantee permanent, and is worth adding as a follow up.
