### PR TITLE
dofs: Add bounded filesystem primitives

### DIFF
--- a/.changeset/dofs-bounded-filesystem.md
+++ b/.changeset/dofs-bounded-filesystem.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/dofs": minor
+---
+
+Add stable directory pagination with metadata, bounded byte reads, single-character globs, and configurable bounded grep results.

--- a/packages/dofs/src/fs/filesystem.test.ts
+++ b/packages/dofs/src/fs/filesystem.test.ts
@@ -10,9 +10,7 @@
 import { describe, expect, it } from "vitest";
 
 import { WorkspaceFilesystem } from "./filesystem.js";
-import { readRangeSync } from "./readFile.js";
 import { withDB } from "./with-db.js";
-import { openWriteBufferSync, releaseWriteBufferSync, writeRangeSync } from "./writeFile.js";
 
 async function withFs<T>(
   fn: (fs: WorkspaceFilesystem) => T | Promise<T>,
@@ -36,28 +34,6 @@ describe("WorkspaceFilesystem", () => {
       expect(stream).toBeInstanceOf(ReadableStream);
       const buf = new Uint8Array(await new Response(stream).arrayBuffer());
       expect(Array.from(buf)).toEqual([1, 2, 3, 4]);
-    });
-  });
-
-  it("readRange returns only the requested bytes", async () => {
-    await withFs(async (fs) => {
-      await fs.writeFile("/bin", new Uint8Array([1, 2, 3, 4, 5]));
-      expect(Array.from(await fs.readRange("/bin", 1, 3))).toEqual([2, 3, 4]);
-      expect(await fs.readRange("/bin", 5, 3)).toEqual(new Uint8Array());
-    });
-  });
-
-  it("readRange returns owned bytes while a write buffer is open", async () => {
-    await withFs(async (fs) => {
-      await fs.writeFile("/bin", new Uint8Array([1, 2, 3]));
-      openWriteBufferSync(fs.db, "/bin");
-      writeRangeSync(fs.db, "/bin", new Uint8Array([4, 5, 6]), 0, {}, () => 1);
-
-      const range = readRangeSync(fs.db, "/bin", 0, 3);
-      range[0] = 99;
-
-      expect(Array.from(readRangeSync(fs.db, "/bin", 0, 3))).toEqual([4, 5, 6]);
-      releaseWriteBufferSync(fs.db, "/bin", () => 2);
     });
   });
 

--- a/packages/dofs/src/fs/filesystem.test.ts
+++ b/packages/dofs/src/fs/filesystem.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from "vitest";
 
 import { WorkspaceFilesystem } from "./filesystem.js";
+import { readRangeSync } from "./readFile.js";
 import { withDB } from "./with-db.js";
 import { openWriteBufferSync, releaseWriteBufferSync, writeRangeSync } from "./writeFile.js";
 
@@ -52,10 +53,10 @@ describe("WorkspaceFilesystem", () => {
       openWriteBufferSync(fs.db, "/bin");
       writeRangeSync(fs.db, "/bin", new Uint8Array([4, 5, 6]), 0, {}, () => 1);
 
-      const range = await fs.readRange("/bin", 0, 3);
+      const range = readRangeSync(fs.db, "/bin", 0, 3);
       range[0] = 99;
 
-      expect(Array.from(await fs.readRange("/bin", 0, 3))).toEqual([4, 5, 6]);
+      expect(Array.from(readRangeSync(fs.db, "/bin", 0, 3))).toEqual([4, 5, 6]);
       releaseWriteBufferSync(fs.db, "/bin", () => 2);
     });
   });

--- a/packages/dofs/src/fs/filesystem.test.ts
+++ b/packages/dofs/src/fs/filesystem.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 
 import { WorkspaceFilesystem } from "./filesystem.js";
 import { withDB } from "./with-db.js";
+import { openWriteBufferSync, releaseWriteBufferSync, writeRangeSync } from "./writeFile.js";
 
 async function withFs<T>(
   fn: (fs: WorkspaceFilesystem) => T | Promise<T>,
@@ -42,6 +43,20 @@ describe("WorkspaceFilesystem", () => {
       await fs.writeFile("/bin", new Uint8Array([1, 2, 3, 4, 5]));
       expect(Array.from(await fs.readRange("/bin", 1, 3))).toEqual([2, 3, 4]);
       expect(await fs.readRange("/bin", 5, 3)).toEqual(new Uint8Array());
+    });
+  });
+
+  it("readRange returns owned bytes while a write buffer is open", async () => {
+    await withFs(async (fs) => {
+      await fs.writeFile("/bin", new Uint8Array([1, 2, 3]));
+      openWriteBufferSync(fs.db, "/bin");
+      writeRangeSync(fs.db, "/bin", new Uint8Array([4, 5, 6]), 0, {}, () => 1);
+
+      const range = await fs.readRange("/bin", 0, 3);
+      range[0] = 99;
+
+      expect(Array.from(await fs.readRange("/bin", 0, 3))).toEqual([4, 5, 6]);
+      releaseWriteBufferSync(fs.db, "/bin", () => 2);
     });
   });
 

--- a/packages/dofs/src/fs/filesystem.test.ts
+++ b/packages/dofs/src/fs/filesystem.test.ts
@@ -37,6 +37,14 @@ describe("WorkspaceFilesystem", () => {
     });
   });
 
+  it("readRange returns only the requested bytes", async () => {
+    await withFs(async (fs) => {
+      await fs.writeFile("/bin", new Uint8Array([1, 2, 3, 4, 5]));
+      expect(Array.from(await fs.readRange("/bin", 1, 3))).toEqual([2, 3, 4]);
+      expect(await fs.readRange("/bin", 5, 3)).toEqual(new Uint8Array());
+    });
+  });
+
   it("stat returns the documented shape for a file", async () => {
     await withFs(async (fs) => {
       await fs.writeFile("/a.txt", "ab");

--- a/packages/dofs/src/fs/filesystem.ts
+++ b/packages/dofs/src/fs/filesystem.ts
@@ -66,7 +66,7 @@ export class WorkspaceFilesystem {
   }
 
   async readRange(path: string, offset: number, length: number): Promise<Uint8Array> {
-    return readRangeSync(this.db, path, offset, length).slice();
+    return readRangeSync(this.db, path, offset, length);
   }
 
   async stat(path: string): Promise<WorkspaceStatResult> {

--- a/packages/dofs/src/fs/filesystem.ts
+++ b/packages/dofs/src/fs/filesystem.ts
@@ -20,7 +20,7 @@ import { type GrepOptions, grep, type WorkspaceGrepMatch } from "./grep.js";
 import { ls } from "./ls.js";
 import { type MkdirOptions, mkdir } from "./mkdir.js";
 import { type ReaddirOptions, readdir, type WorkspaceDirentResult } from "./readdir.js";
-import { type ReadFileOptions, readFile, readRangeSync } from "./readFile.js";
+import { type ReadFileOptions, readFile } from "./readFile.js";
 import { readlink } from "./readlink.js";
 import { type RmOptions, rm } from "./rm.js";
 import { lstat, stat, type WorkspaceStatResult } from "./stat.js";
@@ -63,10 +63,6 @@ export class WorkspaceFilesystem {
     // the class's overloads above carry the precise return type
     // for each input shape back to the caller.
     return readFile(this.db, path, optionsOrEncoding as ReadFileOptions);
-  }
-
-  async readRange(path: string, offset: number, length: number): Promise<Uint8Array> {
-    return readRangeSync(this.db, path, offset, length);
   }
 
   async stat(path: string): Promise<WorkspaceStatResult> {

--- a/packages/dofs/src/fs/filesystem.ts
+++ b/packages/dofs/src/fs/filesystem.ts
@@ -20,7 +20,7 @@ import { type GrepOptions, grep, type WorkspaceGrepMatch } from "./grep.js";
 import { ls } from "./ls.js";
 import { type MkdirOptions, mkdir } from "./mkdir.js";
 import { type ReaddirOptions, readdir, type WorkspaceDirentResult } from "./readdir.js";
-import { type ReadFileOptions, readFile } from "./readFile.js";
+import { type ReadFileOptions, readFile, readRangeSync } from "./readFile.js";
 import { readlink } from "./readlink.js";
 import { type RmOptions, rm } from "./rm.js";
 import { lstat, stat, type WorkspaceStatResult } from "./stat.js";
@@ -58,6 +58,10 @@ export class WorkspaceFilesystem {
     // the class's overloads above carry the precise return type
     // for each input shape back to the caller.
     return readFile(this.db, path, optionsOrEncoding as ReadFileOptions);
+  }
+
+  async readRange(path: string, offset: number, length: number): Promise<Uint8Array> {
+    return readRangeSync(this.db, path, offset, length);
   }
 
   async stat(path: string): Promise<WorkspaceStatResult> {

--- a/packages/dofs/src/fs/filesystem.ts
+++ b/packages/dofs/src/fs/filesystem.ts
@@ -61,7 +61,7 @@ export class WorkspaceFilesystem {
   }
 
   async readRange(path: string, offset: number, length: number): Promise<Uint8Array> {
-    return readRangeSync(this.db, path, offset, length);
+    return readRangeSync(this.db, path, offset, length).slice();
   }
 
   async stat(path: string): Promise<WorkspaceStatResult> {

--- a/packages/dofs/src/fs/filesystem.ts
+++ b/packages/dofs/src/fs/filesystem.ts
@@ -46,6 +46,11 @@ export class WorkspaceFilesystem {
 
   readFile(path: string): Promise<ReadableStream<Uint8Array>>;
   readFile(path: string, encoding: "utf8"): Promise<string>;
+  readFile(
+    path: string,
+    options: ReadFileOptions & { encoding?: undefined },
+  ): Promise<ReadableStream<Uint8Array>>;
+  readFile(path: string, options: ReadFileOptions & { encoding: "utf8" }): Promise<string>;
   readFile(path: string, options: ReadFileOptions): Promise<string | ReadableStream<Uint8Array>>;
   readFile(
     path: string,

--- a/packages/dofs/src/fs/find.test.ts
+++ b/packages/dofs/src/fs/find.test.ts
@@ -54,6 +54,17 @@ describe("find", () => {
     });
   });
 
+  it("matches ? as one non-separator character", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/a", {}, () => 0);
+      await writeFile(db, "/a/a.ts", "", {}, () => 0);
+      await writeFile(db, "/a/ab.ts", "", {}, () => 0);
+      await writeFile(db, "/a/b.ts", "", {}, () => 0);
+      const paths = find(db, "/a", "?.ts").map((entry) => entry.path);
+      expect(paths).toEqual(["/a/a.ts", "/a/b.ts"]);
+    });
+  });
+
   it("matches ** recursively", async () => {
     await withDB(async (db) => {
       mkdir(db, "/a/b/c", { recursive: true }, () => 0);

--- a/packages/dofs/src/fs/find.ts
+++ b/packages/dofs/src/fs/find.ts
@@ -65,6 +65,7 @@ function walk(db: Database, parentInode: number, parentPath: string, out: Worksp
 // Compile a simple glob into a regex. Supported:
 //   *  matches any run of characters except '/'
 //   ** matches any run of characters including '/'
+//   ?  matches one character except '/'
 // Anything else is a literal. Regex metacharacters in literals are
 // escaped so '.' in '*.ts' doesn't match an arbitrary character.
 function compileGlob(pattern: string): RegExp {
@@ -87,6 +88,11 @@ function compileGlob(pattern: string): RegExp {
         re += "[^/]*";
         i += 1;
       }
+      continue;
+    }
+    if (ch === "?") {
+      re += "[^/]";
+      i += 1;
       continue;
     }
     if (REGEX_METACHARS.has(ch)) {

--- a/packages/dofs/src/fs/grep.test.ts
+++ b/packages/dofs/src/fs/grep.test.ts
@@ -90,6 +90,41 @@ describe("grep", () => {
     });
   });
 
+  it("marks adjacent matches as matching context", async () => {
+    await withDB(async (db) => {
+      await writeFile(db, "/a.txt", "TODO one\nTODO two\nplain\n", {}, () => 0);
+
+      const matches = await grep(db, "TODO", "/a.txt", { contextLines: 1 });
+      expect(matches).toEqual([
+        {
+          path: "/a.txt",
+          line: 1,
+          text: "TODO one",
+          context: [
+            { line: 1, text: "TODO one", isMatch: true },
+            { line: 2, text: "TODO two", isMatch: true },
+          ],
+        },
+        {
+          path: "/a.txt",
+          line: 2,
+          text: "TODO two",
+          context: [
+            { line: 1, text: "TODO one", isMatch: true },
+            { line: 2, text: "TODO two", isMatch: true },
+            { line: 3, text: "plain", isMatch: false },
+          ],
+        },
+      ]);
+
+      if (matches[0].context === undefined || matches[1].context === undefined) {
+        throw new Error("expected grep context");
+      }
+      matches[0].context[0].text = "changed";
+      expect(matches[1].context[0].text).toBe("TODO one");
+    });
+  });
+
   it("applies offset and limit across files in path and line order", async () => {
     await withDB(async (db) => {
       await writeFile(db, "/a.txt", "TODO a1\nTODO a2\n", {}, () => 0);

--- a/packages/dofs/src/fs/grep.test.ts
+++ b/packages/dofs/src/fs/grep.test.ts
@@ -43,30 +43,27 @@ describe("grep", () => {
     });
   });
 
-  it("respects explicit case options and the ignoreCase alias", async () => {
+  it("respects the ignoreCase option", async () => {
     await withDB(async (db) => {
       await writeFile(db, "/a.txt", "todo\nTODO\nTodo\n", {}, () => 0);
       expect((await grep(db, "TODO", "/a.txt", { ignoreCase: true })).length).toBe(3);
-      expect((await grep(db, "TODO", "/a.txt", { caseSensitive: false })).length).toBe(3);
-      expect((await grep(db, "TODO", "/a.txt", { caseSensitive: true })).length).toBe(1);
+      expect((await grep(db, "TODO", "/a.txt", { ignoreCase: false })).length).toBe(1);
       expect((await grep(db, "TODO", "/a.txt")).length).toBe(1);
     });
   });
 
-  it("supports regular expressions and fixed strings", async () => {
+  it("supports opt-in regular expressions and literal strings by default", async () => {
     await withDB(async (db) => {
       await writeFile(db, "/a.txt", "task 12\ntask \\d+\ntask xx\n", {}, () => 0);
       expect(
-        (await grep(db, String.raw`task \d+`, "/a.txt", { fixedString: false })).map(
+        (await grep(db, String.raw`task \d+`, "/a.txt", { regex: true })).map(
           (match) => match.line,
         ),
       ).toEqual([1]);
-      expect(
-        (await grep(db, String.raw`task \d+`, "/a.txt", { fixedString: true })).map(
-          (match) => match.line,
-        ),
-      ).toEqual([2]);
-      await expect(grep(db, "[", "/a.txt", { fixedString: false })).rejects.toThrow(
+      expect((await grep(db, String.raw`task \d+`, "/a.txt")).map((match) => match.line)).toEqual([
+        2,
+      ]);
+      await expect(grep(db, "[", "/a.txt", { regex: true })).rejects.toThrow(
         "Invalid regular expression",
       );
     });
@@ -75,7 +72,7 @@ describe("grep", () => {
   it("returns numbered context around matches", async () => {
     await withDB(async (db) => {
       await writeFile(db, "/a.txt", "one\ntwo\nTODO\nfour\nfive\n", {}, () => 0);
-      expect(await grep(db, "TODO", "/a.txt", { contextLines: 1 })).toEqual([
+      expect(await grep(db, "TODO", "/a.txt", { context: 1 })).toEqual([
         {
           path: "/a.txt",
           line: 3,
@@ -94,7 +91,7 @@ describe("grep", () => {
     await withDB(async (db) => {
       await writeFile(db, "/a.txt", "TODO one\nTODO two\nplain\n", {}, () => 0);
 
-      const matches = await grep(db, "TODO", "/a.txt", { contextLines: 1 });
+      const matches = await grep(db, "TODO", "/a.txt", { context: 1 });
       expect(matches).toEqual([
         {
           path: "/a.txt",

--- a/packages/dofs/src/fs/grep.test.ts
+++ b/packages/dofs/src/fs/grep.test.ts
@@ -43,11 +43,62 @@ describe("grep", () => {
     });
   });
 
-  it("respects ignoreCase", async () => {
+  it("respects explicit case options and the ignoreCase alias", async () => {
     await withDB(async (db) => {
       await writeFile(db, "/a.txt", "todo\nTODO\nTodo\n", {}, () => 0);
       expect((await grep(db, "TODO", "/a.txt", { ignoreCase: true })).length).toBe(3);
+      expect((await grep(db, "TODO", "/a.txt", { caseSensitive: false })).length).toBe(3);
+      expect((await grep(db, "TODO", "/a.txt", { caseSensitive: true })).length).toBe(1);
       expect((await grep(db, "TODO", "/a.txt")).length).toBe(1);
+    });
+  });
+
+  it("supports regular expressions and fixed strings", async () => {
+    await withDB(async (db) => {
+      await writeFile(db, "/a.txt", "task 12\ntask \\d+\ntask xx\n", {}, () => 0);
+      expect(
+        (await grep(db, String.raw`task \d+`, "/a.txt", { fixedString: false })).map(
+          (match) => match.line,
+        ),
+      ).toEqual([1]);
+      expect(
+        (await grep(db, String.raw`task \d+`, "/a.txt", { fixedString: true })).map(
+          (match) => match.line,
+        ),
+      ).toEqual([2]);
+      await expect(grep(db, "[", "/a.txt", { fixedString: false })).rejects.toThrow(
+        "Invalid regular expression",
+      );
+    });
+  });
+
+  it("returns numbered context around matches", async () => {
+    await withDB(async (db) => {
+      await writeFile(db, "/a.txt", "one\ntwo\nTODO\nfour\nfive\n", {}, () => 0);
+      expect(await grep(db, "TODO", "/a.txt", { contextLines: 1 })).toEqual([
+        {
+          path: "/a.txt",
+          line: 3,
+          text: "TODO",
+          context: [
+            { line: 2, text: "two", isMatch: false },
+            { line: 3, text: "TODO", isMatch: true },
+            { line: 4, text: "four", isMatch: false },
+          ],
+        },
+      ]);
+    });
+  });
+
+  it("applies offset and limit across files in path and line order", async () => {
+    await withDB(async (db) => {
+      await writeFile(db, "/a.txt", "TODO a1\nTODO a2\n", {}, () => 0);
+      await writeFile(db, "/b.txt", "TODO b1\nTODO b2\n", {}, () => 0);
+      expect(
+        (await grep(db, "TODO", "/", { offset: 1, limit: 2 })).map(
+          (match) => `${match.path}:${match.line}`,
+        ),
+      ).toEqual(["/a.txt:2", "/b.txt:1"]);
     });
   });
 

--- a/packages/dofs/src/fs/grep.ts
+++ b/packages/dofs/src/fs/grep.ts
@@ -19,14 +19,12 @@ export interface WorkspaceGrepMatch {
 }
 
 export interface GrepOptions {
-  /** Compatibility alias for `caseSensitive: false`. */
+  /** Ignore letter case. Defaults to false. */
   ignoreCase?: boolean;
-  /** Match letter case. Defaults to true. */
-  caseSensitive?: boolean;
-  /** Treat the pattern as plain text. Defaults to true. */
-  fixedString?: boolean;
+  /** Interpret the pattern as a regular expression. Defaults to false. */
+  regex?: boolean;
   /** Lines of context to include before and after each match. */
-  contextLines?: number;
+  context?: number;
   /** Maximum matches to return. */
   limit?: number;
   /** Matching lines to skip before collecting results. */
@@ -62,7 +60,10 @@ export async function grep(
 
   const settings = normalizeOptions(options);
   if (settings.limit === 0) return [];
-  const matcher = compileMatcher(pattern, settings.fixedString, settings.caseSensitive);
+  const matcher = compileMatcher(pattern, {
+    regex: settings.regex,
+    ignoreCase: settings.ignoreCase,
+  });
   const filePaths =
     node.type === "file"
       ? [canonical]
@@ -78,7 +79,7 @@ export async function grep(
       db,
       filePath,
       matcher,
-      settings.contextLines,
+      settings.context,
       settings.offset,
       settings.limit,
       state,
@@ -90,22 +91,15 @@ export async function grep(
 }
 
 function normalizeOptions(options: GrepOptions): {
-  caseSensitive: boolean;
-  fixedString: boolean;
-  contextLines: number;
+  ignoreCase: boolean;
+  regex: boolean;
+  context: number;
   limit: number;
   offset: number;
 } {
-  if (
-    options.caseSensitive !== undefined &&
-    options.ignoreCase !== undefined &&
-    options.caseSensitive === options.ignoreCase
-  ) {
-    throw new TypeError("caseSensitive conflicts with ignoreCase");
-  }
-  const contextLines = options.contextLines ?? 0;
-  if (!Number.isSafeInteger(contextLines) || contextLines < 0) {
-    throw new TypeError("grep contextLines must be a non-negative safe integer");
+  const context = options.context ?? 0;
+  if (!Number.isSafeInteger(context) || context < 0) {
+    throw new TypeError("grep context must be a non-negative safe integer");
   }
   const limit = options.limit ?? Number.MAX_SAFE_INTEGER;
   if (!Number.isSafeInteger(limit) || limit < 0) {
@@ -116,18 +110,18 @@ function normalizeOptions(options: GrepOptions): {
     throw new TypeError("grep offset must be a non-negative safe integer");
   }
   return {
-    caseSensitive: options.caseSensitive ?? options.ignoreCase !== true,
-    fixedString: options.fixedString ?? true,
-    contextLines,
+    ignoreCase: options.ignoreCase ?? false,
+    regex: options.regex ?? false,
+    context,
     limit,
     offset,
   };
 }
 
-function compileMatcher(pattern: string, fixedString: boolean, caseSensitive: boolean): RegExp {
-  const source = fixedString ? pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : pattern;
+function compileMatcher(pattern: string, options: { regex: boolean; ignoreCase: boolean }): RegExp {
+  const source = options.regex ? pattern : pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   try {
-    return new RegExp(source, caseSensitive ? "" : "i");
+    return new RegExp(source, options.ignoreCase ? "i" : "");
   } catch (error) {
     throw new TypeError(
       `Invalid regular expression: ${error instanceof Error ? error.message : String(error)}`,
@@ -139,7 +133,7 @@ async function scanFile(
   db: Database,
   path: string,
   matcher: RegExp,
-  contextLines: number,
+  context: number,
   offset: number,
   limit: number,
   state: ScanState,
@@ -163,9 +157,9 @@ async function scanFile(
       state.seen += 1;
       if (matchIndex >= offset && state.accepted < limit) {
         const match: WorkspaceGrepMatch = { path, line: current.line, text: current.text };
-        if (contextLines > 0) {
+        if (context > 0) {
           match.context = [...before.map((line) => ({ ...line })), { ...contextLine }];
-          pending.push({ match, remaining: contextLines });
+          pending.push({ match, remaining: context });
         } else {
           out.push(match);
         }
@@ -174,7 +168,7 @@ async function scanFile(
     }
 
     before.push(contextLine);
-    if (before.length > contextLines) before.shift();
+    if (before.length > context) before.shift();
     if (state.accepted >= limit && pending.length === 0) return true;
   }
 

--- a/packages/dofs/src/fs/grep.ts
+++ b/packages/dofs/src/fs/grep.ts
@@ -5,14 +5,47 @@ import { find } from "./find.js";
 import { readFile } from "./readFile.js";
 import { resolveInode } from "./resolve.js";
 
+export interface WorkspaceGrepContextLine {
+  line: number;
+  text: string;
+  isMatch: boolean;
+}
+
 export interface WorkspaceGrepMatch {
   path: string;
   line: number;
   text: string;
+  context?: WorkspaceGrepContextLine[];
 }
 
 export interface GrepOptions {
+  /** Compatibility alias for `caseSensitive: false`. */
   ignoreCase?: boolean;
+  /** Match letter case. Defaults to true. */
+  caseSensitive?: boolean;
+  /** Treat the pattern as plain text. Defaults to true. */
+  fixedString?: boolean;
+  /** Lines of context to include before and after each match. */
+  contextLines?: number;
+  /** Maximum matches to return. */
+  limit?: number;
+  /** Matching lines to skip before collecting results. */
+  offset?: number;
+}
+
+interface ScanState {
+  seen: number;
+  accepted: number;
+}
+
+interface NumberedLine {
+  line: number;
+  text: string;
+}
+
+interface PendingMatch {
+  match: WorkspaceGrepMatch;
+  remaining: number;
 }
 
 export async function grep(
@@ -27,81 +60,164 @@ export async function grep(
     throw createWorkspaceError("ENOENT", `no such path: ${canonical}`, canonical);
   }
 
+  const settings = normalizeOptions(options);
+  if (settings.limit === 0) return [];
+  const matcher = compileMatcher(pattern, settings.fixedString, settings.caseSensitive);
   const filePaths =
     node.type === "file"
       ? [canonical]
       : find(db, canonical)
           .filter((entry) => entry.type === "file")
-          .map((entry) => entry.path);
+          .map((entry) => entry.path)
+          .sort();
 
   const matches: WorkspaceGrepMatch[] = [];
+  const state: ScanState = { seen: 0, accepted: 0 };
   for (const filePath of filePaths) {
-    await scanFile(db, filePath, pattern, options, matches);
+    const complete = await scanFile(
+      db,
+      filePath,
+      matcher,
+      settings.contextLines,
+      settings.offset,
+      settings.limit,
+      state,
+      matches,
+    );
+    if (complete) break;
   }
   return matches;
 }
 
-// Stream the file in chunks so very large files don't load fully into
-// memory. Carry a partial-line tail between chunks (everything after
-// the last '\n') so a line that straddles a chunk boundary still
-// matches as one line. Line numbers are 1-indexed.
-async function scanFile(
-  db: Database,
-  path: string,
-  pattern: string,
-  options: GrepOptions,
-  out: WorkspaceGrepMatch[],
-): Promise<void> {
-  const stream = await readFile(db, path);
-  const reader = stream.getReader();
-  const decoder = new TextDecoder("utf-8", { fatal: false });
-  const needle = options.ignoreCase ? pattern.toUpperCase() : pattern;
-
-  let tail = "";
-  let lineNo = 1;
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    if (value === undefined) continue;
-    const text = tail + decoder.decode(value, { stream: true });
-    const newlineIdx = text.lastIndexOf("\n");
-    const ready = newlineIdx === -1 ? "" : text.slice(0, newlineIdx);
-    tail = newlineIdx === -1 ? text : text.slice(newlineIdx + 1);
-    if (ready.length > 0) {
-      lineNo = scanLines(ready, lineNo, needle, options.ignoreCase === true, path, out);
-    }
+function normalizeOptions(options: GrepOptions): {
+  caseSensitive: boolean;
+  fixedString: boolean;
+  contextLines: number;
+  limit: number;
+  offset: number;
+} {
+  if (
+    options.caseSensitive !== undefined &&
+    options.ignoreCase !== undefined &&
+    options.caseSensitive === options.ignoreCase
+  ) {
+    throw new TypeError("caseSensitive conflicts with ignoreCase");
   }
-  // Drain the decoder and scan whatever's left (final line without a
-  // trailing newline).
-  tail += decoder.decode();
-  if (tail.length > 0) {
-    scanLines(tail, lineNo, needle, options.ignoreCase === true, path, out);
+  const contextLines = options.contextLines ?? 0;
+  if (!Number.isSafeInteger(contextLines) || contextLines < 0) {
+    throw new TypeError("grep contextLines must be a non-negative safe integer");
+  }
+  const limit = options.limit ?? Number.MAX_SAFE_INTEGER;
+  if (!Number.isSafeInteger(limit) || limit < 0) {
+    throw new TypeError("grep limit must be a non-negative safe integer");
+  }
+  const offset = options.offset ?? 0;
+  if (!Number.isSafeInteger(offset) || offset < 0) {
+    throw new TypeError("grep offset must be a non-negative safe integer");
+  }
+  return {
+    caseSensitive: options.caseSensitive ?? options.ignoreCase !== true,
+    fixedString: options.fixedString ?? true,
+    contextLines,
+    limit,
+    offset,
+  };
+}
+
+function compileMatcher(pattern: string, fixedString: boolean, caseSensitive: boolean): RegExp {
+  const source = fixedString ? pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : pattern;
+  try {
+    return new RegExp(source, caseSensitive ? "" : "i");
+  } catch (error) {
+    throw new TypeError(
+      `Invalid regular expression: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }
 
-// Walk `block` line-by-line, push matches into `out`, return the next
-// 1-indexed line number to use for the following block.
-function scanLines(
-  block: string,
-  startLine: number,
-  needle: string,
-  ignoreCase: boolean,
+async function scanFile(
+  db: Database,
   path: string,
+  matcher: RegExp,
+  contextLines: number,
+  offset: number,
+  limit: number,
+  state: ScanState,
   out: WorkspaceGrepMatch[],
-): number {
-  let line = startLine;
-  let cursor = 0;
-  while (cursor <= block.length) {
-    const next = block.indexOf("\n", cursor);
-    const end = next === -1 ? block.length : next;
-    const text = block.slice(cursor, end);
-    const haystack = ignoreCase ? text.toUpperCase() : text;
-    if (haystack.includes(needle)) {
-      out.push({ path, line, text });
+): Promise<boolean> {
+  const before: NumberedLine[] = [];
+  const pending: PendingMatch[] = [];
+
+  for await (const current of readLines(db, path)) {
+    for (const item of pending) {
+      item.match.context?.push({ ...current, isMatch: false });
+      item.remaining -= 1;
     }
-    line += 1;
-    if (next === -1) break;
-    cursor = next + 1;
+    flushReady(pending, out);
+    if (state.accepted >= limit && pending.length === 0) return true;
+
+    if (matcher.test(current.text)) {
+      const matchIndex = state.seen;
+      state.seen += 1;
+      if (matchIndex >= offset && state.accepted < limit) {
+        const match: WorkspaceGrepMatch = { path, ...current };
+        if (contextLines > 0) {
+          match.context = [
+            ...before.map((line) => ({ ...line, isMatch: false })),
+            { ...current, isMatch: true },
+          ];
+          pending.push({ match, remaining: contextLines });
+        } else {
+          out.push(match);
+        }
+        state.accepted += 1;
+      }
+    }
+
+    before.push(current);
+    if (before.length > contextLines) before.shift();
+    if (state.accepted >= limit && pending.length === 0) return true;
   }
-  return line;
+
+  for (const item of pending) out.push(item.match);
+  return state.accepted >= limit;
+}
+
+function flushReady(pending: PendingMatch[], out: WorkspaceGrepMatch[]): void {
+  while (pending[0]?.remaining === 0) {
+    const item = pending.shift();
+    if (item !== undefined) out.push(item.match);
+  }
+}
+
+async function* readLines(db: Database, path: string): AsyncIterable<NumberedLine> {
+  const stream = await readFile(db, path);
+  const reader = stream.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  let tail = "";
+  let line = 1;
+  let completed = false;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        completed = true;
+        break;
+      }
+      if (value === undefined) continue;
+      tail += decoder.decode(value, { stream: true });
+      let newline = tail.indexOf("\n");
+      while (newline !== -1) {
+        yield { line, text: tail.slice(0, newline) };
+        line += 1;
+        tail = tail.slice(newline + 1);
+        newline = tail.indexOf("\n");
+      }
+    }
+    tail += decoder.decode();
+    if (tail.length > 0) yield { line, text: tail };
+  } finally {
+    if (!completed) await reader.cancel();
+    reader.releaseLock();
+  }
 }

--- a/packages/dofs/src/fs/grep.ts
+++ b/packages/dofs/src/fs/grep.ts
@@ -145,27 +145,26 @@ async function scanFile(
   state: ScanState,
   out: WorkspaceGrepMatch[],
 ): Promise<boolean> {
-  const before: NumberedLine[] = [];
+  const before: WorkspaceGrepContextLine[] = [];
   const pending: PendingMatch[] = [];
 
   for await (const current of readLines(db, path)) {
+    const isMatch = matcher.test(current.text);
+    const contextLine = { ...current, isMatch };
     for (const item of pending) {
-      item.match.context?.push({ ...current, isMatch: false });
+      item.match.context?.push({ ...contextLine });
       item.remaining -= 1;
     }
     flushReady(pending, out);
     if (state.accepted >= limit && pending.length === 0) return true;
 
-    if (matcher.test(current.text)) {
+    if (isMatch) {
       const matchIndex = state.seen;
       state.seen += 1;
       if (matchIndex >= offset && state.accepted < limit) {
-        const match: WorkspaceGrepMatch = { path, ...current };
+        const match: WorkspaceGrepMatch = { path, line: current.line, text: current.text };
         if (contextLines > 0) {
-          match.context = [
-            ...before.map((line) => ({ ...line, isMatch: false })),
-            { ...current, isMatch: true },
-          ];
+          match.context = [...before.map((line) => ({ ...line })), { ...contextLine }];
           pending.push({ match, remaining: contextLines });
         } else {
           out.push(match);
@@ -174,7 +173,7 @@ async function scanFile(
       }
     }
 
-    before.push(current);
+    before.push(contextLine);
     if (before.length > contextLines) before.shift();
     if (state.accepted >= limit && pending.length === 0) return true;
   }

--- a/packages/dofs/src/fs/readFile.test.ts
+++ b/packages/dofs/src/fs/readFile.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from "vitest";
 import { mkdir } from "./mkdir.js";
 import { readFile } from "./readFile.js";
 import { withDB } from "./with-db.js";
-import { CHUNK_SIZE, writeFile } from "./writeFile.js";
+import {
+  CHUNK_SIZE,
+  openWriteBufferForCreateSync,
+  writeFile,
+  writeRangeSync,
+} from "./writeFile.js";
 
 async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
   const reader = stream.getReader();
@@ -69,6 +74,79 @@ describe("readFile", () => {
       expect(second.value?.[0]).toBe(0x42);
       const end = await reader.read();
       expect(end.done).toBe(true);
+    });
+  });
+
+  it("streams only the requested byte range across chunk boundaries", async () => {
+    await withDB(async (db) => {
+      const bytes = new Uint8Array(CHUNK_SIZE + 8);
+      bytes.fill(0x41, 0, CHUNK_SIZE);
+      bytes.fill(0x42, CHUNK_SIZE);
+      await writeFile(db, "/big", bytes, {}, () => 0);
+
+      const stream = await readFile(db, "/big", {
+        byteOffset: CHUNK_SIZE - 4,
+        byteLength: 8,
+      });
+      expect(Array.from(await drain(stream))).toEqual([
+        0x41, 0x41, 0x41, 0x41, 0x42, 0x42, 0x42, 0x42,
+      ]);
+    });
+  });
+
+  it("keeps a ranged stream on the snapshot captured when it opens", async () => {
+    await withDB(async (db) => {
+      const original = new Uint8Array(CHUNK_SIZE + 4);
+      original.fill(0x41, 0, CHUNK_SIZE);
+      original.fill(0x42, CHUNK_SIZE);
+      await writeFile(db, "/big", original, {}, () => 0);
+
+      const stream = await readFile(db, "/big", {
+        byteOffset: CHUNK_SIZE - 2,
+        byteLength: 6,
+      });
+      await writeFile(db, "/big", new Uint8Array(original.byteLength).fill(0x43), {}, () => 1);
+
+      expect(Array.from(await drain(stream))).toEqual([0x41, 0x41, 0x42, 0x42, 0x42, 0x42]);
+    });
+  });
+
+  it("clamps byte ranges at EOF and supports ranged text reads", async () => {
+    await withDB(async (db) => {
+      await writeFile(db, "/a.txt", "hello", {}, () => 0);
+
+      expect(await readFile(db, "/a.txt", { encoding: "utf8", byteOffset: 1, byteLength: 3 })).toBe(
+        "ell",
+      );
+      expect(
+        (await drain(await readFile(db, "/a.txt", { byteOffset: 4, byteLength: 10 })))[0],
+      ).toBe(0x6f);
+      expect(await drain(await readFile(db, "/a.txt", { byteOffset: 5 }))).toHaveLength(0);
+      expect(await drain(await readFile(db, "/a.txt", { byteLength: 0 }))).toHaveLength(0);
+    });
+  });
+
+  it("snapshots ranged reads from pending write buffers", async () => {
+    await withDB(async (db) => {
+      openWriteBufferForCreateSync(db, "/pending", {}, () => 0);
+      writeRangeSync(db, "/pending", new TextEncoder().encode("abcdef"), 0, {}, () => 1);
+
+      const stream = await readFile(db, "/pending", { byteOffset: 1, byteLength: 3 });
+      writeRangeSync(db, "/pending", new TextEncoder().encode("ZZZ"), 1, {}, () => 2);
+
+      expect(new TextDecoder().decode(await drain(stream))).toBe("bcd");
+    });
+  });
+
+  it("rejects invalid byte ranges", async () => {
+    await withDB(async (db) => {
+      await writeFile(db, "/a.txt", "hello", {}, () => 0);
+      await expect(readFile(db, "/a.txt", { byteOffset: -1 })).rejects.toMatchObject({
+        code: "EINVAL",
+      });
+      await expect(
+        readFile(db, "/a.txt", { byteLength: Number.MAX_SAFE_INTEGER + 1 }),
+      ).rejects.toMatchObject({ code: "EINVAL" });
     });
   });
 

--- a/packages/dofs/src/fs/readFile.ts
+++ b/packages/dofs/src/fs/readFile.ts
@@ -164,7 +164,7 @@ function snapshotResult(
 }
 
 function assertDenseRange(
-  chunks: ChunkRow[],
+  chunks: Array<Pick<ChunkRow, "idx">>,
   firstIdx: number,
   lastIdx: number,
   path: string,
@@ -243,15 +243,15 @@ export function readRangeSync(
   const end = Math.min(offset + length, totalSize);
   const firstIdx = Math.floor(offset / CHUNK_SIZE);
   const lastIdx = Math.floor((end - 1) / CHUNK_SIZE);
-  // Pull every overlapping chunk in one indexed range scan. Missing
-  // indices (a sparse file) simply don't come back, so the assembly
-  // below compacts around the gaps exactly as a per-index walk would.
+  // Pull every overlapping chunk in one indexed range scan. Files are
+  // represented densely; a missing row indicates corrupt storage.
   const chunks = db.all<{ idx: number; hash: Uint8Array }>(
     "SELECT idx, hash FROM vfs_chunks WHERE inode = ? AND idx BETWEEN ? AND ? ORDER BY idx",
     node.inode,
     firstIdx,
     lastIdx,
   );
+  assertDenseRange(chunks, firstIdx, lastIdx, path);
   const out = new Uint8Array(end - offset);
   let written = 0;
   for (const { idx, hash } of chunks) {
@@ -266,5 +266,8 @@ export function readRangeSync(
     out.set(bytes.subarray(srcStart, srcEnd), written);
     written += srcEnd - srcStart;
   }
-  return written === out.byteLength ? out : out.subarray(0, written);
+  if (written !== out.byteLength) {
+    throw createWorkspaceError("EIO", `incomplete chunk data for ${path}`, path);
+  }
+  return out;
 }

--- a/packages/dofs/src/fs/readFile.ts
+++ b/packages/dofs/src/fs/readFile.ts
@@ -8,9 +8,17 @@ import { CHUNK_SIZE } from "./writeFile.js";
 
 export interface ReadFileOptions {
   encoding?: "utf8";
+  /** First byte to return. Defaults to 0. */
+  byteOffset?: number;
+  /** Maximum bytes to return. Defaults to the rest of the file. */
+  byteLength?: number;
 }
 
+type BinaryReadFileOptions = ReadFileOptions & { encoding?: undefined };
+type TextReadFileOptions = ReadFileOptions & { encoding: "utf8" };
+
 interface ChunkRow {
+  idx: number;
   hash: Uint8Array;
   size: number;
 }
@@ -21,6 +29,12 @@ export function readFile(db: Database, path: string, encoding: "utf8"): Promise<
 export function readFile(
   db: Database,
   path: string,
+  options: BinaryReadFileOptions,
+): Promise<ReadableStream<Uint8Array>>;
+export function readFile(db: Database, path: string, options: TextReadFileOptions): Promise<string>;
+export function readFile(
+  db: Database,
+  path: string,
   options: ReadFileOptions,
 ): Promise<string | ReadableStream<Uint8Array>>;
 export async function readFile(
@@ -28,23 +42,20 @@ export async function readFile(
   path: string,
   optionsOrEncoding?: "utf8" | ReadFileOptions,
 ): Promise<string | ReadableStream<Uint8Array>> {
+  const options = typeof optionsOrEncoding === "object" ? optionsOrEncoding : undefined;
   const wantString =
-    optionsOrEncoding === "utf8" ||
-    (typeof optionsOrEncoding === "object" && optionsOrEncoding?.encoding === "utf8");
+    optionsOrEncoding === "utf8" || (options !== undefined && options.encoding === "utf8");
+  const byteOffset = options?.byteOffset ?? 0;
+  const byteLength = options?.byteLength;
+  validateReadWindow(path, byteOffset, byteLength);
 
-  // Pending-create files surface through the path-keyed buffer.
+  // Pending-create files surface through the path-keyed buffer. Copy only the
+  // requested window so the returned stream remains a snapshot while writes
+  // continue through the open buffer.
   const { path: canonical } = canonicalizePath(path);
   const pending = getPendingWriteBufferByPath(db, canonical);
   if (pending !== undefined) {
-    const snapshot = new Uint8Array(pending.size);
-    snapshot.set(pending.buf.subarray(0, pending.size));
-    if (wantString) return new TextDecoder().decode(snapshot);
-    return new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(snapshot);
-        controller.close();
-      },
-    });
+    return snapshotResult(pending.buf, pending.size, byteOffset, byteLength, wantString);
   }
 
   // Resolve up front so we surface ENOENT/EISDIR before doing any
@@ -57,64 +68,129 @@ export async function readFile(
     throw createWorkspaceError("EISDIR", `path is a directory: ${path}`, path);
   }
 
-  // While a write buffer is open for this inode it is the source of
-  // truth. Skip the chunk store and serve the buffered bytes.
+  // While a write buffer is open for this inode it is the source of truth.
+  // Snapshot only the selected bytes instead of touching the chunk store.
   const buffered = getWriteBuffer(db, node.inode);
   if (buffered?.dirty) {
-    const snapshot = new Uint8Array(buffered.size);
-    snapshot.set(buffered.buf.subarray(0, buffered.size));
-    if (wantString) return new TextDecoder().decode(snapshot);
-    return new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(snapshot);
-        controller.close();
-      },
-    });
+    return snapshotResult(buffered.buf, buffered.size, byteOffset, byteLength, wantString);
   }
 
-  const chunks = db.all<ChunkRow>(
-    "SELECT hash, size FROM vfs_chunks WHERE inode = ? ORDER BY idx",
-    node.inode,
-  );
+  const { start, end, length } = readWindow(node.size, byteOffset, byteLength);
+  const firstIdx = length === 0 ? 0 : Math.floor(start / CHUNK_SIZE);
+  const lastIdx = length === 0 ? -1 : Math.floor((end - 1) / CHUNK_SIZE);
+  const chunks =
+    length === 0
+      ? []
+      : db.all<ChunkRow>(
+          `SELECT idx, hash, size
+             FROM vfs_chunks
+            WHERE inode = ? AND idx BETWEEN ? AND ?
+            ORDER BY idx`,
+          node.inode,
+          firstIdx,
+          lastIdx,
+        );
+  assertDenseRange(chunks, firstIdx, lastIdx, path);
 
   if (wantString) {
-    // Fast path — concatenate everything and decode once. Matches the
-    // node:fs/promises.readFile semantics for an encoding argument:
-    // memory cost = whole file.
-    const totalSize = chunks.reduce((acc, c) => acc + c.size, 0);
-    const out = new Uint8Array(totalSize);
-    let offset = 0;
+    // String reads intentionally materialize the selected range so it can be
+    // decoded once. Binary callers receive the lazy stream below.
+    const out = new Uint8Array(length);
+    let written = 0;
     for (const chunk of chunks) {
-      const bytes = getBlobBytes(db, chunk.hash);
-      if (bytes === undefined) {
-        throw createWorkspaceError("EIO", `missing blob bytes for ${path}`, path);
-      }
-      out.set(bytes, offset);
-      offset += bytes.byteLength;
+      const bytes = rangedChunkBytes(db, path, chunk, start, end);
+      out.set(bytes, written);
+      written += bytes.byteLength;
     }
     return new TextDecoder().decode(out);
   }
 
-  // Stream form. We enqueue one Uint8Array per chunk, lazily pulled.
-  // Reads resolve bytes by hash and never restamp last_seen: a chunk
-  // being read is already linked to a node, so gc's orphan gate keeps
-  // it. last_seen only guards blobs staged but not yet linked.
-  let i = 0;
+  // The row list is captured once when the stream opens. Blob hashes are
+  // immutable, so later writes cannot tear the returned range. Pulling stays
+  // lazy and preserves backpressure across the RPC stream.
+  let index = 0;
   return new ReadableStream<Uint8Array>({
     pull(controller) {
-      if (i >= chunks.length) {
+      if (index >= chunks.length) {
         controller.close();
         return;
       }
-      const chunk = chunks[i++];
-      const bytes = getBlobBytes(db, chunk.hash);
-      if (bytes === undefined) {
-        controller.error(createWorkspaceError("EIO", `missing blob bytes for ${path}`, path));
-        return;
-      }
-      controller.enqueue(bytes);
+      const chunk = chunks[index++];
+      controller.enqueue(rangedChunkBytes(db, path, chunk, start, end));
     },
   });
+}
+
+function validateReadWindow(
+  path: string,
+  byteOffset: number,
+  byteLength: number | undefined,
+): void {
+  if (!Number.isSafeInteger(byteOffset) || byteOffset < 0) {
+    throw createWorkspaceError("EINVAL", `invalid read offset: ${byteOffset}`, path);
+  }
+  if (byteLength !== undefined && (!Number.isSafeInteger(byteLength) || byteLength < 0)) {
+    throw createWorkspaceError("EINVAL", `invalid read length: ${byteLength}`, path);
+  }
+}
+
+function readWindow(
+  size: number,
+  byteOffset: number,
+  byteLength: number | undefined,
+): { start: number; end: number; length: number } {
+  const start = Math.min(byteOffset, size);
+  const available = size - start;
+  const length = byteLength === undefined ? available : Math.min(available, byteLength);
+  return { start, end: start + length, length };
+}
+
+function snapshotResult(
+  source: Uint8Array,
+  size: number,
+  byteOffset: number,
+  byteLength: number | undefined,
+  wantString: boolean,
+): string | ReadableStream<Uint8Array> {
+  const { start, end } = readWindow(size, byteOffset, byteLength);
+  const snapshot = source.slice(start, end);
+  if (wantString) return new TextDecoder().decode(snapshot);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (snapshot.byteLength > 0) controller.enqueue(snapshot);
+      controller.close();
+    },
+  });
+}
+
+function assertDenseRange(
+  chunks: ChunkRow[],
+  firstIdx: number,
+  lastIdx: number,
+  path: string,
+): void {
+  for (let idx = firstIdx; idx <= lastIdx; idx += 1) {
+    if (chunks[idx - firstIdx]?.idx !== idx) {
+      throw createWorkspaceError("EIO", `missing chunk data for ${path}`, path);
+    }
+  }
+}
+
+function rangedChunkBytes(
+  db: Database,
+  path: string,
+  chunk: ChunkRow,
+  start: number,
+  end: number,
+): Uint8Array {
+  const bytes = getBlobBytes(db, chunk.hash);
+  if (bytes === undefined) {
+    throw createWorkspaceError("EIO", `missing blob bytes for ${path}`, path);
+  }
+  const chunkStart = chunk.idx * CHUNK_SIZE;
+  const from = Math.max(0, start - chunkStart);
+  const to = Math.min(bytes.byteLength, end - chunkStart);
+  return bytes.subarray(from, to);
 }
 
 // Positional read primitive. Walks only the chunk rows that overlap

--- a/packages/dofs/src/fs/readFile.ts
+++ b/packages/dofs/src/fs/readFile.ts
@@ -216,7 +216,7 @@ export function readRangeSync(
     if (length === 0) return new Uint8Array();
     if (offset >= pending.size) return new Uint8Array();
     const end = Math.min(offset + length, pending.size);
-    return pending.buf.subarray(offset, end);
+    return pending.buf.slice(offset, end);
   }
   const node = resolveInode(db, path);
   if (node === null) {
@@ -234,7 +234,7 @@ export function readRangeSync(
   if (buffered?.dirty) {
     if (offset >= buffered.size) return new Uint8Array();
     const end = Math.min(offset + length, buffered.size);
-    return buffered.buf.subarray(offset, end);
+    return buffered.buf.slice(offset, end);
   }
 
   // node.size is the cached value resolveInode just loaded.

--- a/packages/dofs/src/fs/readRange.test.ts
+++ b/packages/dofs/src/fs/readRange.test.ts
@@ -3,7 +3,13 @@ import { describe, expect, it } from "vitest";
 import { readRangeSync } from "./readFile.js";
 import { resolveInode } from "./resolve.js";
 import { withDB } from "./with-db.js";
-import { CHUNK_SIZE, writeFileSync } from "./writeFile.js";
+import {
+  CHUNK_SIZE,
+  openWriteBufferSync,
+  releaseWriteBufferSync,
+  writeFileSync,
+  writeRangeSync,
+} from "./writeFile.js";
 
 describe("readRangeSync", () => {
   it("reads small chunk-backed files at non-zero offset", async () => {
@@ -22,6 +28,20 @@ describe("readRangeSync", () => {
       expect(readRangeSync(db, "/inline.txt", 0, 100).byteLength).toBe(3);
       expect(readRangeSync(db, "/inline.txt", 2, 100).byteLength).toBe(1);
       expect(readRangeSync(db, "/inline.txt", 3, 100).byteLength).toBe(0);
+    });
+  });
+
+  it("returns owned bytes while a write buffer is open", async () => {
+    await withDB((db) => {
+      writeFileSync(db, "/bin", new Uint8Array([1, 2, 3]), {}, () => 1);
+      openWriteBufferSync(db, "/bin");
+      writeRangeSync(db, "/bin", new Uint8Array([4, 5, 6]), 0, {}, () => 1);
+
+      const range = readRangeSync(db, "/bin", 0, 3);
+      range[0] = 99;
+
+      expect(Array.from(readRangeSync(db, "/bin", 0, 3))).toEqual([4, 5, 6]);
+      releaseWriteBufferSync(db, "/bin", () => 2);
     });
   });
 

--- a/packages/dofs/src/fs/readRange.test.ts
+++ b/packages/dofs/src/fs/readRange.test.ts
@@ -90,25 +90,16 @@ describe("readRangeSync", () => {
     });
   });
 
-  it("compacts around a missing chunk row rather than zero-filling", async () => {
+  it("throws EIO when a chunk row is missing", async () => {
     await withDB((db) => {
       const original = new Uint8Array(CHUNK_SIZE * 3);
-      original.fill(1, 0, CHUNK_SIZE);
-      original.fill(2, CHUNK_SIZE, CHUNK_SIZE * 2);
-      original.fill(3, CHUNK_SIZE * 2);
       writeFileSync(db, "/large.bin", original, {}, () => 1);
       const node = resolveInode(db, "/large.bin");
-      // Drop the middle chunk row (node.size still reports three
-      // chunks). The read elides the gap and returns the present
-      // chunks concatenated, trimmed to what was actually read.
       db.run("DELETE FROM vfs_chunks WHERE inode = ? AND idx = 1", node?.inode ?? 0);
 
-      const slice = readRangeSync(db, "/large.bin", 0, CHUNK_SIZE * 3);
-      expect(slice.byteLength).toBe(CHUNK_SIZE * 2);
-      expect(slice[0]).toBe(1);
-      expect(slice[CHUNK_SIZE - 1]).toBe(1);
-      expect(slice[CHUNK_SIZE]).toBe(3);
-      expect(slice[CHUNK_SIZE * 2 - 1]).toBe(3);
+      expect(() => readRangeSync(db, "/large.bin", 0, CHUNK_SIZE * 3)).toThrowError(
+        expect.objectContaining({ code: "EIO" }),
+      );
     });
   });
 

--- a/packages/dofs/src/fs/readdir.test.ts
+++ b/packages/dofs/src/fs/readdir.test.ts
@@ -116,6 +116,30 @@ describe("readdir", () => {
     });
   });
 
+  it("keeps UTF-8 filename pages stable when a pending file commits", async () => {
+    await withDB(async (db) => {
+      const bmpName = "\uE000";
+      const astralName = "\u{10000}";
+      await writeFile(db, `/${bmpName}`, "committed", {}, () => 0);
+      openWriteBufferForCreateSync(db, `/${astralName}`, {}, () => 1);
+
+      expect(readdir(db, "/", { limit: 1, offset: 0 }).map((entry) => entry.name)).toEqual([
+        bmpName,
+      ]);
+      expect(readdir(db, "/", { limit: 1, offset: 1 }).map((entry) => entry.name)).toEqual([
+        astralName,
+      ]);
+
+      releaseWriteBufferSync(db, `/${astralName}`, () => 2);
+      expect(readdir(db, "/", { limit: 1, offset: 0 }).map((entry) => entry.name)).toEqual([
+        bmpName,
+      ]);
+      expect(readdir(db, "/", { limit: 1, offset: 1 }).map((entry) => entry.name)).toEqual([
+        astralName,
+      ]);
+    });
+  });
+
   it("rejects invalid offsets", async () => {
     await withDB((db) => {
       expect(() => readdir(db, "/", { offset: -1 })).toThrowError(

--- a/packages/dofs/src/fs/readdir.test.ts
+++ b/packages/dofs/src/fs/readdir.test.ts
@@ -6,9 +6,9 @@ import { withDB } from "./with-db.js";
 import {
   openWriteBufferForCreateSync,
   releaseWriteBufferSync,
+  writeFile,
   writeRangeSync,
 } from "./writeFile.js";
-import { writeFile } from "./writeFile.js";
 
 describe("readdir", () => {
   it("returns an empty array for an empty directory", async () => {

--- a/packages/dofs/src/fs/readdir.test.ts
+++ b/packages/dofs/src/fs/readdir.test.ts
@@ -3,6 +3,11 @@ import { describe, expect, it } from "vitest";
 import { mkdir } from "./mkdir.js";
 import { readdir } from "./readdir.js";
 import { withDB } from "./with-db.js";
+import {
+  openWriteBufferForCreateSync,
+  releaseWriteBufferSync,
+  writeRangeSync,
+} from "./writeFile.js";
 import { writeFile } from "./writeFile.js";
 
 describe("readdir", () => {
@@ -22,6 +27,8 @@ describe("readdir", () => {
       expect(entries).toContainEqual({
         name: "file.txt",
         parentPath: "/",
+        size: 1,
+        mtime: 0,
         isFile: true,
         isDirectory: false,
         isSymbolicLink: false,
@@ -29,6 +36,8 @@ describe("readdir", () => {
       expect(entries).toContainEqual({
         name: "sub",
         parentPath: "/",
+        size: 0,
+        mtime: 0,
         isFile: false,
         isDirectory: true,
         isSymbolicLink: false,
@@ -45,10 +54,53 @@ describe("readdir", () => {
     });
   });
 
-  it("limits committed entries before materializing the result", async () => {
+  it("paginates committed entries by stable name order", async () => {
     await withDB(async (db) => {
-      for (const name of ["a", "b", "c"]) await writeFile(db, `/${name}`, "", {}, () => 0);
-      expect(readdir(db, "/", { limit: 2 }).map((entry) => entry.name)).toEqual(["a", "b"]);
+      for (const name of ["a", "b", "c", "d"]) {
+        await writeFile(db, `/${name}`, name, {}, () => 0);
+      }
+      expect(readdir(db, "/", { limit: 2, offset: 0 }).map((entry) => entry.name)).toEqual([
+        "a",
+        "b",
+      ]);
+      expect(readdir(db, "/", { limit: 2, offset: 2 }).map((entry) => entry.name)).toEqual([
+        "c",
+        "d",
+      ]);
+    });
+  });
+
+  it("merges pending files before applying pagination", async () => {
+    await withDB(async (db) => {
+      for (const name of ["a", "c", "e"]) {
+        await writeFile(db, `/${name}`, name, {}, () => 0);
+      }
+      openWriteBufferForCreateSync(db, "/b", {}, () => 10);
+      writeRangeSync(db, "/b", new TextEncoder().encode("pending"), 0, {}, () => 11);
+
+      expect(readdir(db, "/", { limit: 2, offset: 0 }).map((entry) => entry.name)).toEqual([
+        "a",
+        "b",
+      ]);
+      expect(readdir(db, "/", { limit: 2, offset: 2 }).map((entry) => entry.name)).toEqual([
+        "c",
+        "e",
+      ]);
+      expect(readdir(db, "/", { limit: 2, offset: 0 })[1]).toMatchObject({
+        name: "b",
+        size: 7,
+        mtime: 10,
+      });
+
+      releaseWriteBufferSync(db, "/b", () => 12);
+    });
+  });
+
+  it("rejects invalid offsets", async () => {
+    await withDB((db) => {
+      expect(() => readdir(db, "/", { offset: -1 })).toThrowError(
+        "readdir offset must be a non-negative safe integer",
+      );
     });
   });
 
@@ -62,6 +114,8 @@ describe("readdir", () => {
         {
           name: "leaf.txt",
           parentPath: "/a/b",
+          size: 1,
+          mtime: 0,
           isFile: true,
           isDirectory: false,
           isSymbolicLink: false,

--- a/packages/dofs/src/fs/readdir.test.ts
+++ b/packages/dofs/src/fs/readdir.test.ts
@@ -96,6 +96,22 @@ describe("readdir", () => {
     });
   });
 
+  it("ignores a pending file whose committed entry is outside the requested page", async () => {
+    await withDB(async (db) => {
+      for (const name of ["b", "c", "d", "e", "f", "g", "h"]) {
+        await writeFile(db, `/${name}`, name, {}, () => 0);
+      }
+      openWriteBufferForCreateSync(db, "/a", {}, () => 10);
+      await writeFile(db, "/landed", "committed", {}, () => 11);
+      db.run("UPDATE vfs_dirents SET name = ? WHERE name = ?", "a", "landed");
+
+      expect(readdir(db, "/", { limit: 2, offset: 5 }).map((entry) => entry.name)).toEqual([
+        "f",
+        "g",
+      ]);
+    });
+  });
+
   it("bounds committed rows fetched for a deep page with a pending file", async () => {
     await withDB(async (db) => {
       for (let index = 0; index < 30; index += 1) {

--- a/packages/dofs/src/fs/readdir.test.ts
+++ b/packages/dofs/src/fs/readdir.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { mkdir } from "./mkdir.js";
 import { readdir } from "./readdir.js";
@@ -93,6 +93,26 @@ describe("readdir", () => {
       });
 
       releaseWriteBufferSync(db, "/b", () => 12);
+    });
+  });
+
+  it("bounds committed rows fetched for a deep page with a pending file", async () => {
+    await withDB(async (db) => {
+      for (let index = 0; index < 30; index += 1) {
+        const name = `file-${index.toString().padStart(2, "0")}`;
+        await writeFile(db, `/${name}`, name, {}, () => 0);
+      }
+      openWriteBufferForCreateSync(db, "/pending", {}, () => 10);
+
+      const all = vi.spyOn(db, "all");
+      expect(readdir(db, "/", { limit: 2, offset: 25 }).map((entry) => entry.name)).toEqual([
+        "file-25",
+        "file-26",
+      ]);
+      const pageQuery = all.mock.calls.find(([query]) =>
+        String(query).includes("FROM vfs_dirents d"),
+      );
+      expect(pageQuery?.slice(-2)).toEqual([4, 24]);
     });
   });
 

--- a/packages/dofs/src/fs/readdir.ts
+++ b/packages/dofs/src/fs/readdir.ts
@@ -70,14 +70,17 @@ export function readdir(
 
   // Pending creates live outside SQLite until their final release. If there
   // are none, let SQLite apply the requested page directly. Otherwise fetch
-  // only enough committed rows to merge the requested page in name order.
-  const queryOffset = pending.length === 0 ? offset : 0;
+  // a narrow committed window around the requested page. Every pending entry
+  // can shift the committed offset by at most one position in either
+  // direction, so this window is sufficient without materializing the whole
+  // prefix before a deep page.
+  const queryOffset = pending.length === 0 ? offset : Math.max(0, offset - pending.length);
   const queryLimit =
     pending.length === 0
       ? limit
       : limit === undefined
         ? undefined
-        : Math.min(Number.MAX_SAFE_INTEGER, offset + limit);
+        : Math.min(Number.MAX_SAFE_INTEGER, limit + pending.length * 2);
   const rows = readRows(db, node.inode, queryLimit, queryOffset);
   const entries = rows.map((row) => toResult(db, canonical, row));
 
@@ -88,7 +91,8 @@ export function readdir(
     if (!seen.has(entry.name)) entries.push(entry);
   }
   entries.sort(compareByName);
-  return entries.slice(offset, limit === undefined ? undefined : offset + limit);
+  const localOffset = offset - queryOffset;
+  return entries.slice(localOffset, limit === undefined ? undefined : localOffset + limit);
 }
 
 function readRows(

--- a/packages/dofs/src/fs/readdir.ts
+++ b/packages/dofs/src/fs/readdir.ts
@@ -147,6 +147,14 @@ function toResult(db: Database, parentPath: string, row: DirentRow): WorkspaceDi
   };
 }
 
+const filenameEncoder = new TextEncoder();
+
 function compareByName(a: WorkspaceDirentResult, b: WorkspaceDirentResult): number {
-  return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+  const left = filenameEncoder.encode(a.name);
+  const right = filenameEncoder.encode(b.name);
+  const length = Math.min(left.byteLength, right.byteLength);
+  for (let index = 0; index < length; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return left.byteLength - right.byteLength;
 }

--- a/packages/dofs/src/fs/readdir.ts
+++ b/packages/dofs/src/fs/readdir.ts
@@ -2,24 +2,32 @@ import { createWorkspaceError } from "../errors.js";
 import { canonicalizePath } from "../path.js";
 import type { Database } from "../storage.js";
 import { resolveInode } from "./resolve.js";
-import { listPendingByParent } from "./writeBuffer.js";
+import { getWriteBuffer, listPendingByParent } from "./writeBuffer.js";
 
 export interface WorkspaceDirentResult {
   name: string;
   parentPath: string;
+  size: number;
+  mtime: number;
   isFile: boolean;
   isDirectory: boolean;
   isSymbolicLink: boolean;
 }
 
 interface DirentRow {
+  inode: number;
   name: string;
   type: "file" | "dir" | "symlink";
+  size: number;
+  mtime: number;
+  link_target: string | null;
 }
 
 export interface ReaddirOptions {
-  /** Maximum committed entries to materialize. Pending entries may extend the result. */
+  /** Maximum entries to return. */
   limit?: number;
+  /** Number of entries to skip in name order. */
+  offset?: number;
 }
 
 export function readdir(
@@ -40,45 +48,101 @@ export function readdir(
   if (limit !== undefined && (!Number.isSafeInteger(limit) || limit < 0)) {
     throw new TypeError("readdir limit must be a non-negative safe integer");
   }
-  const rows = db.all<DirentRow>(
-    `SELECT d.name AS name, n.type AS type
+  const offset = options.offset ?? 0;
+  if (!Number.isSafeInteger(offset) || offset < 0) {
+    throw new TypeError("readdir offset must be a non-negative safe integer");
+  }
+  if (limit === 0) return [];
+
+  const pending = listPendingByParent(db, node.inode)
+    .filter((entry) => entry.pending !== undefined)
+    .map(
+      (entry): WorkspaceDirentResult => ({
+        name: entry.pending?.leafName ?? "",
+        parentPath: canonical,
+        size: entry.size,
+        mtime: entry.pending?.mtime ?? 0,
+        isFile: true,
+        isDirectory: false,
+        isSymbolicLink: false,
+      }),
+    );
+
+  // Pending creates live outside SQLite until their final release. If there
+  // are none, let SQLite apply the requested page directly. Otherwise fetch
+  // only enough committed rows to merge the requested page in name order.
+  const queryOffset = pending.length === 0 ? offset : 0;
+  const queryLimit =
+    pending.length === 0
+      ? limit
+      : limit === undefined
+        ? undefined
+        : Math.min(Number.MAX_SAFE_INTEGER, offset + limit);
+  const rows = readRows(db, node.inode, queryLimit, queryOffset);
+  const entries = rows.map((row) => toResult(db, canonical, row));
+
+  if (pending.length === 0) return entries;
+
+  const seen = new Set(entries.map((entry) => entry.name));
+  for (const entry of pending) {
+    if (!seen.has(entry.name)) entries.push(entry);
+  }
+  entries.sort(compareByName);
+  return entries.slice(offset, limit === undefined ? undefined : offset + limit);
+}
+
+function readRows(
+  db: Database,
+  parentInode: number,
+  limit: number | undefined,
+  offset: number,
+): DirentRow[] {
+  const pagination =
+    limit !== undefined ? "LIMIT ? OFFSET ?" : offset > 0 ? "LIMIT -1 OFFSET ?" : "";
+  const params =
+    limit !== undefined
+      ? [parentInode, limit, offset]
+      : offset > 0
+        ? [parentInode, offset]
+        : [parentInode];
+  return db.all<DirentRow>(
+    `SELECT n.inode AS inode,
+            d.name AS name,
+            n.type AS type,
+            n.size AS size,
+            n.mtime AS mtime,
+            n.link_target AS link_target
        FROM vfs_dirents d
        JOIN vfs_nodes n ON n.inode = d.child_inode
       WHERE d.parent_inode = ?
       ORDER BY d.name
-      ${limit === undefined ? "" : "LIMIT ?"}`,
-    ...(limit === undefined ? [node.inode] : [node.inode, limit]),
+      ${pagination}`,
+    ...params,
   );
+}
 
-  const entries = rows.map((row) => ({
+function toResult(db: Database, parentPath: string, row: DirentRow): WorkspaceDirentResult {
+  const isFile = row.type === "file";
+  const isSymbolicLink = row.type === "symlink";
+  const buffered = isFile ? getWriteBuffer(db, row.inode) : undefined;
+  const size = isFile
+    ? buffered?.dirty
+      ? buffered.size
+      : row.size
+    : isSymbolicLink
+      ? (row.link_target ?? "").length
+      : 0;
+  return {
     name: row.name,
-    parentPath: canonical,
-    isFile: row.type === "file",
+    parentPath,
+    size,
+    mtime: row.mtime,
+    isFile,
     isDirectory: row.type === "dir",
-    isSymbolicLink: row.type === "symlink",
-  }));
+    isSymbolicLink,
+  };
+}
 
-  // Merge in pending-create buffers parented under this directory so
-  // a `readdir` between FUSE create and release still surfaces the
-  // file. Skip any whose name already appears in the SQL rows (in
-  // case a concurrent commit just landed it).
-  const pending = listPendingByParent(db, node.inode);
-  if (pending.length > 0) {
-    const seen = new Set(entries.map((e) => e.name));
-    for (const entry of pending) {
-      if (entry.pending === undefined) continue;
-      const { leafName } = entry.pending;
-      if (seen.has(leafName)) continue;
-      entries.push({
-        name: leafName,
-        parentPath: canonical,
-        isFile: true,
-        isDirectory: false,
-        isSymbolicLink: false,
-      });
-    }
-    entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-  }
-
-  return entries;
+function compareByName(a: WorkspaceDirentResult, b: WorkspaceDirentResult): number {
+  return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
 }

--- a/packages/dofs/src/fs/readdir.ts
+++ b/packages/dofs/src/fs/readdir.ts
@@ -54,7 +54,7 @@ export function readdir(
   }
   if (limit === 0) return [];
 
-  const pending = listPendingByParent(db, node.inode)
+  let pending = listPendingByParent(db, node.inode)
     .filter((entry) => entry.pending !== undefined)
     .map(
       (entry): WorkspaceDirentResult => ({
@@ -67,6 +67,14 @@ export function readdir(
         isSymbolicLink: false,
       }),
     );
+
+  // A concurrent apply can commit the same name while a pending-create
+  // buffer is still open. Remove those pending duplicates before calculating
+  // the committed window; otherwise they shift the page even when the
+  // committed row falls outside that window.
+  if (pending.length > 0 && (limit !== undefined || offset > 0)) {
+    pending = pending.filter((entry) => !committedNameExists(db, node.inode, entry.name));
+  }
 
   // Pending creates live outside SQLite until their final release. If there
   // are none, let SQLite apply the requested page directly. Otherwise fetch
@@ -93,6 +101,16 @@ export function readdir(
   entries.sort(compareByName);
   const localOffset = offset - queryOffset;
   return entries.slice(localOffset, limit === undefined ? undefined : localOffset + limit);
+}
+
+function committedNameExists(db: Database, parentInode: number, name: string): boolean {
+  return (
+    db.one<{ present: number }>(
+      "SELECT 1 AS present FROM vfs_dirents WHERE parent_inode = ? AND name = ? LIMIT 1",
+      parentInode,
+      name,
+    ) !== undefined
+  );
 }
 
 function readRows(

--- a/packages/dofs/src/index.ts
+++ b/packages/dofs/src/index.ts
@@ -6,7 +6,11 @@ export {
   type WorkspaceFilesystemOptions,
 } from "./fs/filesystem.js";
 export type { WorkspaceFoundEntry } from "./fs/find.js";
-export type { GrepOptions, WorkspaceGrepMatch } from "./fs/grep.js";
+export type {
+  GrepOptions,
+  WorkspaceGrepContextLine,
+  WorkspaceGrepMatch,
+} from "./fs/grep.js";
 export { link } from "./fs/link.js";
 export type { MkdirOptions } from "./fs/mkdir.js";
 // Read-only mount enforcement. The workspace-side indexer writes


### PR DESCRIPTION
*Stack 1 of 7. Base: `main`. Head: `stack/improve-tools-01-dofs-primitives`.*

The storage filesystem could not page directories after merging pending writes, expose bounded byte reads through its main facade, match single-character globs, or bound search results. Tool callers therefore had to transfer too much data or implement behavior outside the authoritative storage layer.

This change adds stable name-ordered directory pages with size and modification time, including entries held in write buffers. It exposes byte-range reads on `WorkspaceFilesystem`, adds `?` glob matching, and extends `grep` with fixed-string and regular-expression modes, explicit case handling, context lines, limits, and offsets. Existing `grep` callers retain literal, case-sensitive defaults.

**Verification**

```sh
npm test --workspace @cloudflare/dofs
npm run typecheck --workspace @cloudflare/dofs
npm run build --workspace @cloudflare/dofs
```

The next stack part carries these bounded primitives through the Computer facade and AI tool adapters.
