### PR TITLE
computer: Expose bounded filesystem operations

### DIFF
--- a/.changeset/computer-bounded-filesystem.md
+++ b/.changeset/computer-bounded-filesystem.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/computer": minor
+---
+
+Expose bounded workspace byte reads through RPC and return paginated directory listings with file metadata.

--- a/packages/computer/src/stub.test.ts
+++ b/packages/computer/src/stub.test.ts
@@ -205,6 +205,14 @@ describe("WorkspaceStub", () => {
     });
   });
 
+  it("fs.readRange forwards bounded byte reads", async () => {
+    await withStub(async (ws) => {
+      const stub = ws.stub();
+      await stub.fs.writeFile("/bin", new Uint8Array([1, 2, 3, 4, 5]));
+      expect(Array.from(await stub.fs.readRange("/bin", 1, 3))).toEqual([2, 3, 4]);
+    });
+  });
+
   it("fs.readdir forwards bounded-read options", async () => {
     await withStub(async (ws) => {
       const stub = ws.stub();

--- a/packages/computer/src/stub.test.ts
+++ b/packages/computer/src/stub.test.ts
@@ -205,6 +205,16 @@ describe("WorkspaceStub", () => {
     });
   });
 
+  it("fs.readFile forwards ranged stream options", async () => {
+    await withStub(async (ws) => {
+      const stub = ws.stub();
+      await stub.fs.writeFile("/bin", new Uint8Array([1, 2, 3, 4, 5]));
+      const stream = await stub.fs.readFile("/bin", { byteOffset: 1, byteLength: 3 });
+      const bytes = new Uint8Array(await new Response(stream).arrayBuffer());
+      expect(Array.from(bytes)).toEqual([2, 3, 4]);
+    });
+  });
+
   it("fs.readRange forwards bounded byte reads", async () => {
     await withStub(async (ws) => {
       const stub = ws.stub();

--- a/packages/computer/src/stub.test.ts
+++ b/packages/computer/src/stub.test.ts
@@ -215,14 +215,6 @@ describe("WorkspaceStub", () => {
     });
   });
 
-  it("fs.readRange forwards bounded byte reads", async () => {
-    await withStub(async (ws) => {
-      const stub = ws.stub();
-      await stub.fs.writeFile("/bin", new Uint8Array([1, 2, 3, 4, 5]));
-      expect(Array.from(await stub.fs.readRange("/bin", 1, 3))).toEqual([2, 3, 4]);
-    });
-  });
-
   it("fs.readdir forwards bounded-read options", async () => {
     await withStub(async (ws) => {
       const stub = ws.stub();

--- a/packages/computer/src/stub.ts
+++ b/packages/computer/src/stub.ts
@@ -119,15 +119,6 @@ export class WorkspaceFilesystemStub extends RpcTarget {
     );
   }
 
-  readRange(path: string, offset: number, length: number): Promise<Uint8Array> {
-    return withSpan(
-      this.#ws.observer,
-      "workspace.fs.readRange",
-      { "workspace.fs.path": path, "workspace.fs.offset": offset, "workspace.fs.length": length },
-      () => this.#ws.fs.readRange(path, offset, length),
-    );
-  }
-
   exists(path: string): Promise<boolean> {
     return withSpan(
       this.#ws.observer,

--- a/packages/computer/src/stub.ts
+++ b/packages/computer/src/stub.ts
@@ -114,6 +114,15 @@ export class WorkspaceFilesystemStub extends RpcTarget {
     );
   }
 
+  readRange(path: string, offset: number, length: number): Promise<Uint8Array> {
+    return withSpan(
+      this.#ws.observer,
+      "workspace.fs.readRange",
+      { "workspace.fs.path": path, "workspace.fs.offset": offset, "workspace.fs.length": length },
+      () => this.#ws.fs.readRange(path, offset, length),
+    );
+  }
+
   exists(path: string): Promise<boolean> {
     return withSpan(
       this.#ws.observer,

--- a/packages/computer/src/stub.ts
+++ b/packages/computer/src/stub.ts
@@ -104,6 +104,11 @@ export class WorkspaceFilesystemStub extends RpcTarget {
 
   readFile(path: string): Promise<ReadableStream<Uint8Array>>;
   readFile(path: string, encoding: "utf8"): Promise<string>;
+  readFile(
+    path: string,
+    options: ReadFileOptions & { encoding?: undefined },
+  ): Promise<ReadableStream<Uint8Array>>;
+  readFile(path: string, options: ReadFileOptions & { encoding: "utf8" }): Promise<string>;
   readFile(path: string, options: ReadFileOptions): Promise<string | ReadableStream<Uint8Array>>;
   readFile(
     path: string,

--- a/packages/computer/src/tools/ai.test.ts
+++ b/packages/computer/src/tools/ai.test.ts
@@ -289,7 +289,17 @@ describe("createAITools filesystem tools", () => {
     );
     await expect(executeTool(tools.ls, { path: "/workspace/notes" })).resolves.toEqual({
       path: "/workspace/notes",
-      entries: [{ name: "todo.txt", isFile: true, isDirectory: false }],
+      count: 1,
+      entries: [
+        {
+          name: "todo.txt",
+          size: 8,
+          mtime: 1_700_000_000_000,
+          isFile: true,
+          isDirectory: false,
+          isSymbolicLink: false,
+        },
+      ],
     });
     await expect(
       executeTool(tools.read, { path: "/workspace/notes/todo.txt", limit: 1 }),
@@ -311,6 +321,32 @@ describe("createAITools filesystem tools", () => {
     await expect(workspace.fs.readFile("/workspace/notes/todo.txt", "utf8")).resolves.toBe(
       "one\nthree\n",
     );
+  });
+
+  it("paginates ls results and reports a continuation offset", async () => {
+    const workspace = makeWorkspace();
+    await workspace.fs.mkdir("/workspace", { recursive: true });
+    for (const name of ["a", "b", "c"]) {
+      await workspace.fs.writeFile(`/workspace/${name}`, name);
+    }
+    const tools = createAITools({ workspace });
+
+    await expect(
+      executeTool(tools.ls, { path: "/workspace", limit: 2, offset: 0 }),
+    ).resolves.toMatchObject({
+      count: 2,
+      entries: [
+        { name: "a", size: 1 },
+        { name: "b", size: 1 },
+      ],
+      nextOffset: 2,
+    });
+    await expect(
+      executeTool(tools.ls, { path: "/workspace", limit: 2, offset: 2 }),
+    ).resolves.toMatchObject({
+      count: 1,
+      entries: [{ name: "c", size: 1 }],
+    });
   });
 
   it("preserves file mode when write overwrites an existing file", async () => {

--- a/packages/computer/src/tools/ai.test.ts
+++ b/packages/computer/src/tools/ai.test.ts
@@ -179,33 +179,34 @@ function memoryStore(options: {
 }
 
 describe("WorkspaceFileStore", () => {
-  it("uses readRange without streaming skipped bytes from Workspace.fs", async () => {
-    const calls: Array<{ offset: number; length: number }> = [];
+  it("opens one ranged stream instead of issuing repeated range calls", async () => {
+    const calls: Array<{ byteOffset?: number; byteLength?: number }> = [];
     const content = bytes("abcdefghij");
     const workspace = {
       fs: {
         async stat() {
-          return {
-            size: content.length,
-            mtime: 1,
-            mode: 0o100644,
-            isFile: true,
-            isDirectory: false,
-          };
+          throw new Error("stat must not be called by readChunks");
         },
-        async readRange(_path: string, offset: number, length: number) {
-          calls.push({ offset, length });
-          return content.slice(offset, offset + length);
+        async readRange() {
+          throw new Error("readRange must not be called by readChunks");
         },
-        async readFile(): Promise<ReadableStream<Uint8Array>> {
-          throw new Error("readFile must not be called for ranged reads");
+        async readFile(
+          _path: string,
+          options: { byteOffset?: number; byteLength?: number } = {},
+        ): Promise<ReadableStream<Uint8Array>> {
+          calls.push(options);
+          const start = options.byteOffset ?? 0;
+          const end = options.byteLength === undefined ? undefined : start + options.byteLength;
+          return new ReadableStream({
+            start(controller) {
+              controller.enqueue(content.slice(start, end));
+              controller.close();
+            },
+          });
         },
         async writeFile() {},
         async mkdir() {},
         async rm() {},
-        async readdir() {
-          return [];
-        },
       },
     };
     const store = new WorkspaceFileStore(workspace);
@@ -213,48 +214,89 @@ describe("WorkspaceFileStore", () => {
     await expect(
       drainChunks(store.readChunks("/workspace/range.txt", 2, 5)).then(decode),
     ).resolves.toBe("cdefg");
-    expect(calls).toEqual([{ offset: 2, length: 5 }]);
+    expect(calls).toEqual([{ byteOffset: 2, byteLength: 5 }]);
   });
 
-  it("splits unbounded reads into fixed-size ranges", async () => {
-    const calls: Array<{ offset: number; length: number }> = [];
-    const content = new Uint8Array(150_000).fill(7);
+  it("still validates the path for a zero-length read", async () => {
+    const store = new WorkspaceFileStore(makeWorkspace());
+
+    await expect(drainChunks(store.readChunks("/missing", 0, 0))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("rejects directories instead of treating them as empty files", async () => {
+    const workspace = makeWorkspace();
+    await workspace.fs.mkdir("/directory");
+    const store = new WorkspaceFileStore(workspace);
+
+    await expect(drainChunks(store.readChunks("/directory"))).rejects.toMatchObject({
+      code: "EISDIR",
+    });
+  });
+
+  it("keeps a real multi-chunk workspace read on one snapshot", async () => {
+    const workspace = makeWorkspace();
+    await workspace.fs.mkdir("/workspace", { recursive: true });
+    const original = new Uint8Array(600_000);
+    original.fill(0x41, 0, 500_000);
+    original.fill(0x42, 500_000);
+    await workspace.fs.writeFile("/workspace/large.bin", original);
+    const store = new WorkspaceFileStore(workspace);
+
+    const chunks = store.readChunks("/workspace/large.bin")[Symbol.asyncIterator]();
+    const first = await chunks.next();
+    expect(first.done).toBe(false);
+    await workspace.fs.writeFile(
+      "/workspace/large.bin",
+      new Uint8Array(original.length).fill(0x43),
+    );
+
+    const parts = [first.value];
+    while (true) {
+      const next = await chunks.next();
+      if (next.done) break;
+      parts.push(next.value);
+    }
+    const result = await drainChunks(
+      (async function* () {
+        yield* parts;
+      })(),
+    );
+    expect(result.byteLength).toBe(original.byteLength);
+    expect(result.every((value, index) => value === original[index])).toBe(true);
+  });
+
+  it("cancels a ranged stream when its consumer stops early", async () => {
+    let cancelled = false;
     const workspace = {
       fs: {
         async stat() {
-          return {
-            size: content.length,
-            mtime: 1,
-            mode: 0o100644,
-            isFile: true,
-            isDirectory: false,
-          };
+          throw new Error("stat must not be called by readChunks");
         },
-        async readRange(_path: string, offset: number, length: number) {
-          calls.push({ offset, length });
-          return content.slice(offset, offset + length);
+        async readRange() {
+          throw new Error("readRange must not be called by readChunks");
         },
         async readFile(): Promise<ReadableStream<Uint8Array>> {
-          throw new Error("readFile must not be called for ranged reads");
+          return new ReadableStream({
+            start(controller) {
+              controller.enqueue(bytes("first"));
+              controller.enqueue(bytes("second"));
+            },
+            cancel() {
+              cancelled = true;
+            },
+          });
         },
         async writeFile() {},
         async mkdir() {},
         async rm() {},
-        async readdir() {
-          return [];
-        },
       },
     };
     const store = new WorkspaceFileStore(workspace);
 
-    await expect(drainChunks(store.readChunks("/workspace/large.bin"))).resolves.toHaveLength(
-      content.length,
-    );
-    expect(calls).toEqual([
-      { offset: 0, length: 65_536 },
-      { offset: 65_536, length: 65_536 },
-      { offset: 131_072, length: 18_928 },
-    ]);
+    for await (const _chunk of store.readChunks("/workspace/range.txt")) break;
+    expect(cancelled).toBe(true);
   });
 });
 

--- a/packages/computer/src/tools/ai.test.ts
+++ b/packages/computer/src/tools/ai.test.ts
@@ -179,33 +179,26 @@ function memoryStore(options: {
 }
 
 describe("WorkspaceFileStore", () => {
-  it("slices byte ranges while reading chunks from Workspace.fs", async () => {
-    const workspace = makeWorkspace();
-    await workspace.fs.mkdir("/workspace", { recursive: true });
-    await workspace.fs.writeFile("/workspace/range.txt", bytes("abcdefghij"));
-    const store = new WorkspaceFileStore(workspace);
-
-    await expect(
-      drainChunks(store.readChunks("/workspace/range.txt", 2, 5)).then(decode),
-    ).resolves.toBe("cdefg");
-  });
-
-  it("cancels read streams when a byte range stops before EOF", async () => {
-    let cancelled = false;
+  it("uses readRange without streaming skipped bytes from Workspace.fs", async () => {
+    const calls: Array<{ offset: number; length: number }> = [];
+    const content = bytes("abcdefghij");
     const workspace = {
       fs: {
         async stat() {
-          return { size: 10, mtime: 1, mode: 0o100644, isFile: true, isDirectory: false };
+          return {
+            size: content.length,
+            mtime: 1,
+            mode: 0o100644,
+            isFile: true,
+            isDirectory: false,
+          };
         },
-        async readFile() {
-          return new ReadableStream<Uint8Array>({
-            start(controller) {
-              controller.enqueue(bytes("abcdefghij"));
-            },
-            cancel() {
-              cancelled = true;
-            },
-          });
+        async readRange(_path: string, offset: number, length: number) {
+          calls.push({ offset, length });
+          return content.slice(offset, offset + length);
+        },
+        async readFile(): Promise<ReadableStream<Uint8Array>> {
+          throw new Error("readFile must not be called for ranged reads");
         },
         async writeFile() {},
         async mkdir() {},
@@ -220,7 +213,48 @@ describe("WorkspaceFileStore", () => {
     await expect(
       drainChunks(store.readChunks("/workspace/range.txt", 2, 5)).then(decode),
     ).resolves.toBe("cdefg");
-    expect(cancelled).toBe(true);
+    expect(calls).toEqual([{ offset: 2, length: 5 }]);
+  });
+
+  it("splits unbounded reads into fixed-size ranges", async () => {
+    const calls: Array<{ offset: number; length: number }> = [];
+    const content = new Uint8Array(150_000).fill(7);
+    const workspace = {
+      fs: {
+        async stat() {
+          return {
+            size: content.length,
+            mtime: 1,
+            mode: 0o100644,
+            isFile: true,
+            isDirectory: false,
+          };
+        },
+        async readRange(_path: string, offset: number, length: number) {
+          calls.push({ offset, length });
+          return content.slice(offset, offset + length);
+        },
+        async readFile(): Promise<ReadableStream<Uint8Array>> {
+          throw new Error("readFile must not be called for ranged reads");
+        },
+        async writeFile() {},
+        async mkdir() {},
+        async rm() {},
+        async readdir() {
+          return [];
+        },
+      },
+    };
+    const store = new WorkspaceFileStore(workspace);
+
+    await expect(drainChunks(store.readChunks("/workspace/large.bin"))).resolves.toHaveLength(
+      content.length,
+    );
+    expect(calls).toEqual([
+      { offset: 0, length: 65_536 },
+      { offset: 65_536, length: 65_536 },
+      { offset: 131_072, length: 18_928 },
+    ]);
   });
 });
 

--- a/packages/computer/src/tools/fs/list.ts
+++ b/packages/computer/src/tools/fs/list.ts
@@ -3,7 +3,19 @@ import { z } from "zod";
 
 export interface ListWorkspaceLike {
   fs: {
-    readdir(path: string): Promise<Array<{ name: string; isFile: boolean; isDirectory: boolean }>>;
+    readdir(
+      path: string,
+      options?: { limit?: number; offset?: number },
+    ): Promise<
+      Array<{
+        name: string;
+        size: number;
+        mtime: number;
+        isFile: boolean;
+        isDirectory: boolean;
+        isSymbolicLink: boolean;
+      }>
+    >;
   };
 }
 
@@ -11,26 +23,55 @@ export interface ListToolOptions {
   workspace: ListWorkspaceLike;
 }
 
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 1000;
+
 const inputSchema = z.object({
   path: z.string().describe("Absolute directory path to list, e.g. /workspace/src."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_LIMIT)
+    .optional()
+    .describe(`Maximum entries to return. Defaults to ${DEFAULT_LIMIT}.`),
+  offset: z.number().int().min(0).optional().describe("Number of entries to skip in name order."),
 });
 
 export function createListTool(options: ListToolOptions): Tool<z.infer<typeof inputSchema>> {
   return tool({
     description:
-      "List entries in a workspace directory. Returns each entry name and whether it is a file or directory.",
+      "List entries in a workspace directory with file sizes and modification times. Use limit and offset to page through large directories.",
     inputSchema,
-    execute: async ({ path }) => {
+    execute: async ({ path, limit, offset }) => {
       try {
-        const entries = await options.workspace.fs.readdir(path);
-        return {
+        const pageSize = limit ?? DEFAULT_LIMIT;
+        const pageOffset = offset ?? 0;
+        const entries = await options.workspace.fs.readdir(path, {
+          limit: pageSize + 1,
+          offset: pageOffset,
+        });
+        const truncated = entries.length > pageSize;
+        const page = (truncated ? entries.slice(0, pageSize) : entries).map((entry) => ({
+          name: entry.name,
+          size: entry.size,
+          mtime: entry.mtime,
+          isFile: entry.isFile,
+          isDirectory: entry.isDirectory,
+          isSymbolicLink: entry.isSymbolicLink,
+        }));
+        const result: {
+          path: string;
+          count: number;
+          entries: typeof page;
+          nextOffset?: number;
+        } = {
           path,
-          entries: entries.map((entry) => ({
-            name: entry.name,
-            isFile: entry.isFile,
-            isDirectory: entry.isDirectory,
-          })),
+          count: page.length,
+          entries: page,
         };
+        if (truncated) result.nextOffset = pageOffset + pageSize;
+        return result;
       } catch (err) {
         return { error: err instanceof Error ? err.message : String(err) };
       }

--- a/packages/computer/src/tools/fs/store.ts
+++ b/packages/computer/src/tools/fs/store.ts
@@ -6,13 +6,12 @@
  * class. This adapter is the bridge from that contract to the public
  * `workspace.fs` surface.
  *
- * Bounded reads go through `fs.readRange`; whole-file reads used by edit
- * and multimodal output still drain `fs.readFile(path)`.
+ * Chunked and ranged reads use one `fs.readFile` stream so remote workspaces
+ * keep one snapshot and one RPC invocation. Whole-file reads used by edit and
+ * multimodal output drain the same stream interface.
  */
 
 import type { FileStat, FileStore } from "./types.js";
-
-const RANGE_CHUNK_BYTES = 64 * 1024;
 
 /**
  * Structural subset of `@cloudflare/computer.Workspace` the tools
@@ -27,8 +26,10 @@ export interface WorkspaceLike {
       isFile: boolean;
       isDirectory: boolean;
     }>;
-    readFile(path: string): Promise<ReadableStream<Uint8Array>>;
-    readRange(path: string, offset: number, length: number): Promise<Uint8Array>;
+    readFile(
+      path: string,
+      options?: { byteOffset?: number; byteLength?: number },
+    ): Promise<ReadableStream<Uint8Array>>;
     writeFile(path: string, content: Uint8Array, options?: { mode?: number }): Promise<void>;
     mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
     rm(path: string, options?: { recursive?: boolean; force?: boolean }): Promise<void>;
@@ -84,20 +85,24 @@ export class WorkspaceFileStore implements FileStore {
     if (byteLength !== undefined && (!Number.isSafeInteger(byteLength) || byteLength < 0)) {
       throw new Error("readChunks: byteLength must be a non-negative safe integer");
     }
-    if (byteLength === 0) return;
-
-    const stat = await this.ws.fs.stat(path);
-    let remaining = Math.max(0, stat.size - byteOffset);
-    if (byteLength !== undefined) remaining = Math.min(remaining, byteLength);
-    let offset = byteOffset;
-    while (remaining > 0) {
-      const requested = Math.min(remaining, RANGE_CHUNK_BYTES);
-      const chunk = await this.ws.fs.readRange(path, offset, requested);
-      if (chunk.byteLength === 0) return;
-      yield chunk;
-      offset += chunk.byteLength;
-      remaining -= chunk.byteLength;
-      if (chunk.byteLength < requested) return;
+    const stream = await this.ws.fs.readFile(path, { byteOffset, byteLength });
+    const reader = stream.getReader();
+    let completed = false;
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          completed = true;
+          return;
+        }
+        if (value !== undefined && value.byteLength > 0) yield value;
+      }
+    } finally {
+      try {
+        if (!completed) await reader.cancel();
+      } finally {
+        reader.releaseLock();
+      }
     }
   }
 }

--- a/packages/computer/src/tools/fs/store.ts
+++ b/packages/computer/src/tools/fs/store.ts
@@ -6,12 +6,13 @@
  * class. This adapter is the bridge from that contract to the public
  * `workspace.fs` surface.
  *
- * Reads go through `fs.readFile(path)` as a `ReadableStream<Uint8Array>`
- * and are stitched together either chunk-by-chunk (`readChunks`) or all
- * at once (`readAll`).
+ * Bounded reads go through `fs.readRange`; whole-file reads used by edit
+ * and multimodal output still drain `fs.readFile(path)`.
  */
 
 import type { FileStat, FileStore } from "./types.js";
+
+const RANGE_CHUNK_BYTES = 64 * 1024;
 
 /**
  * Structural subset of `@cloudflare/computer.Workspace` the tools
@@ -27,10 +28,23 @@ export interface WorkspaceLike {
       isDirectory: boolean;
     }>;
     readFile(path: string): Promise<ReadableStream<Uint8Array>>;
+    readRange(path: string, offset: number, length: number): Promise<Uint8Array>;
     writeFile(path: string, content: Uint8Array, options?: { mode?: number }): Promise<void>;
     mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
     rm(path: string, options?: { recursive?: boolean; force?: boolean }): Promise<void>;
-    readdir(path: string): Promise<Array<{ name: string; isFile: boolean; isDirectory: boolean }>>;
+    readdir(
+      path: string,
+      options?: { limit?: number; offset?: number },
+    ): Promise<
+      Array<{
+        name: string;
+        size: number;
+        mtime: number;
+        isFile: boolean;
+        isDirectory: boolean;
+        isSymbolicLink: boolean;
+      }>
+    >;
   };
 }
 
@@ -64,55 +78,26 @@ export class WorkspaceFileStore implements FileStore {
   }
 
   async *readChunks(path: string, byteOffset = 0, byteLength?: number): AsyncIterable<Uint8Array> {
-    if (byteOffset < 0) throw new Error("readChunks: byteOffset must be non-negative");
-    if (byteLength !== undefined && byteLength < 0) {
-      throw new Error("readChunks: byteLength must be non-negative");
+    if (!Number.isSafeInteger(byteOffset) || byteOffset < 0) {
+      throw new Error("readChunks: byteOffset must be a non-negative safe integer");
+    }
+    if (byteLength !== undefined && (!Number.isSafeInteger(byteLength) || byteLength < 0)) {
+      throw new Error("readChunks: byteLength must be a non-negative safe integer");
     }
     if (byteLength === 0) return;
 
-    const stream = await this.ws.fs.readFile(path);
-    const reader = stream.getReader();
-    let skipped = 0;
-    let yielded = 0;
-    let completed = false;
-    try {
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) {
-          completed = true;
-          break;
-        }
-        if (!value || value.byteLength === 0) continue;
-
-        let start = 0;
-        if (skipped < byteOffset) {
-          const needed = byteOffset - skipped;
-          if (value.byteLength <= needed) {
-            skipped += value.byteLength;
-            continue;
-          }
-          start = needed;
-          skipped = byteOffset;
-        }
-
-        let end = value.byteLength;
-        if (byteLength !== undefined) {
-          const remaining = byteLength - yielded;
-          if (remaining <= 0) break;
-          end = Math.min(end, start + remaining);
-        }
-
-        if (end > start) {
-          const chunk = value.slice(start, end);
-          yielded += chunk.byteLength;
-          yield chunk;
-        }
-
-        if (byteLength !== undefined && yielded >= byteLength) break;
-      }
-    } finally {
-      if (!completed) await reader.cancel();
-      reader.releaseLock();
+    const stat = await this.ws.fs.stat(path);
+    let remaining = Math.max(0, stat.size - byteOffset);
+    if (byteLength !== undefined) remaining = Math.min(remaining, byteLength);
+    let offset = byteOffset;
+    while (remaining > 0) {
+      const requested = Math.min(remaining, RANGE_CHUNK_BYTES);
+      const chunk = await this.ws.fs.readRange(path, offset, requested);
+      if (chunk.byteLength === 0) return;
+      yield chunk;
+      offset += chunk.byteLength;
+      remaining -= chunk.byteLength;
+      if (chunk.byteLength < requested) return;
     }
   }
 }


### PR DESCRIPTION
*Stack 2 of 7. Base: `stack/improve-tools-01-dofs-primitives`. Head: `stack/improve-tools-02-computer-fs-plumbing`.*

Computer's file store previously implemented an offset by streaming from byte zero and discarding everything before it. Paging through a large file could therefore transfer the same prefix repeatedly. Directory listings also omitted useful metadata and had no continuation.

This change carries `readRange` through the Workers RPC filesystem stub and makes `WorkspaceFileStore` request fixed 64 KiB windows. It also makes `ls` return file size and modification time in bounded, stable pages with `nextOffset` when more entries remain.

**Verification**

```sh
npm run typecheck --workspace @cloudflare/computer
npm test --workspace @cloudflare/computer -- src/stub.test.ts src/tools/ai.test.ts
```

The next stack part builds the complete search and mutation tool set on this bounded facade.
