### PR TITLE
computer: Remove Think compatibility

### DIFF
--- a/.changeset/remove-think-compatibility.md
+++ b/.changeset/remove-think-compatibility.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/computer": minor
+---
+
+Remove the deprecated `useThink` compatibility layer. Think integrations must use `workspace.fs` and `@cloudflare/computer/tools` directly.

--- a/docs/01_vfs.md
+++ b/docs/01_vfs.md
@@ -34,16 +34,10 @@ Workspace where `fs` works against the local SQLite store but
 `shell` throws.
 
 `WorkspaceOptions` includes the storage handle, optional backends,
-clock, session id, mounts, observer, git identity, assets, artifacts,
-and `useThink`. There is no `root` or `sandbox` field on the host
-facade — sandbox wiring lives behind a `WorkspaceBackend`.
-
-Set `useThink: true` when assigning the Workspace to
-`Think.workspace`. This adds Think's string-oriented filesystem
-compatibility methods (`readFile`, `readFileBytes`, `writeFile`,
-`readDir`, `rm`, `glob`, `mkdir`, and `stat`) to that Workspace and to
-clients returned by `getWorkspace()`, while leaving the primary API on
-`workspace.fs`.
+clock, session id, mounts, observer, git identity, assets, and artifacts.
+There is no `root` or `sandbox` field on the host facade — sandbox wiring
+lives behind a `WorkspaceBackend`. Think integrations use `workspace.fs`
+and `@cloudflare/computer/tools` directly.
 
 Illustrative layout (nothing below `/` is auto-created beyond
 `ROOT_INODE` itself):

--- a/packages/computer/README.md
+++ b/packages/computer/README.md
@@ -465,9 +465,9 @@ await ws.ready();
 const stub = ws.stub();  // crosses the Workers-RPC boundary
 ```
 
-When assigning a workspace to a Think agent's `workspace`, pass
-`useThink: true` so Think's compatibility methods are added alongside
-`workspace.fs` and `workspace.runtime`.
+Think integrations use `workspace.fs`, `workspace.runtime`, and
+`@cloudflare/computer/tools` directly. The legacy root-level filesystem
+compatibility methods are not available.
 
 ### Durable pending-sync retries
 

--- a/packages/computer/src/client.test.ts
+++ b/packages/computer/src/client.test.ts
@@ -10,9 +10,9 @@
 import { SQLiteTestStorage } from "@cloudflare/dofs/testing";
 import { describe, expect, it } from "vitest";
 
-import { getWorkspace, type WorkspaceClient } from "./client.js";
+import { getWorkspace } from "./client.js";
 import { WORKSPACE, type WorkspaceStubHost } from "./with-workspace.js";
-import { type ThinkWorkspaceCompatibility, Workspace } from "./workspace.js";
+import { Workspace } from "./workspace.js";
 
 interface ExecCall {
   command: string;
@@ -87,7 +87,6 @@ function fakeRemote(): {
   let disposed = false;
   const stub = {
     fs: { marker: "fs" },
-    useThink: false,
     git: { marker: "git" },
     assets: undefined,
     artifacts: { marker: "artifacts" },
@@ -104,14 +103,20 @@ function fakeRemote(): {
   };
 }
 
-function fakeBrokenRemote(): {
+function fakeLegacyFlagRemote(): {
   host: WorkspaceStubHost;
   disposed: () => boolean;
 } {
+  const { runtime } = fakeRuntime(true);
   let disposed = false;
   const stub = {
+    fs: { marker: "fs" },
+    runtime,
+    git: { marker: "git" },
+    assets: undefined,
+    artifacts: { marker: "artifacts" },
     get useThink(): boolean {
-      throw new Error("compatibility lookup failed");
+      throw new Error("legacy compatibility flag was read");
     },
     [Symbol.dispose]() {
       disposed = true;
@@ -177,28 +182,14 @@ describe("getWorkspace — remote dispatch", () => {
     expect(disposed()).toBe(true);
   });
 
-  it("disposes the remote stub when client initialization fails", async () => {
-    const { host, disposed } = fakeBrokenRemote();
+  it("does not inspect the removed remote useThink flag", async () => {
+    const { host, disposed } = fakeLegacyFlagRemote();
 
-    await expect(getWorkspace(host)).rejects.toThrow("compatibility lookup failed");
+    const ws = await getWorkspace(host);
+    expect(ws.fs).toEqual({ marker: "fs" });
+    expect(disposed()).toBe(false);
+    ws[Symbol.dispose]();
     expect(disposed()).toBe(true);
-  });
-
-  it("adds Think compatibility when the remote Workspace enables it", async () => {
-    const workspace = new Workspace({
-      storage: new SQLiteTestStorage(),
-      useThink: true,
-    });
-    await workspace.fs.writeFile("/notes.txt", "hello");
-    const host: WorkspaceStubHost = {
-      __getWorkspaceStub: () => Promise.resolve(workspace.stub()),
-    };
-
-    const client = (await getWorkspace(host)) as WorkspaceClient & ThinkWorkspaceCompatibility;
-
-    expect(client).toHaveProperty("readFile");
-    await expect(client.readFile("/notes.txt")).resolves.toBe("hello");
-    await expect(client.readFile("/missing.txt")).resolves.toBeNull();
   });
 });
 
@@ -215,20 +206,6 @@ describe("getWorkspace — local dispatch", () => {
     const { host } = fakeLocal();
     const ws = await getWorkspace(host);
     expect(() => ws[Symbol.dispose]()).not.toThrow();
-  });
-
-  it("adds Think compatibility when the local Workspace enables it", async () => {
-    const workspace = new Workspace({
-      storage: new SQLiteTestStorage(),
-      useThink: true,
-    });
-    const host = { [WORKSPACE]: workspace };
-    const { runtime } = fakeRuntime();
-    Object.defineProperty(workspace, "runtime", { get: () => runtime });
-
-    const client = (await getWorkspace(host)) as WorkspaceClient & ThinkWorkspaceCompatibility;
-
-    expect(client).toHaveProperty("readFile");
   });
 });
 

--- a/packages/computer/src/client.ts
+++ b/packages/computer/src/client.ts
@@ -42,11 +42,7 @@ import { decodeRuntimeEvents } from "./runtime/wire.js";
 import { type ShellValue, sh } from "./sh.js";
 import type { ExecEncoding } from "./shell.js";
 import { WORKSPACE, type WorkspaceStubHost } from "./with-workspace.js";
-import {
-  createThinkCompatibility,
-  type ThinkWorkspaceCompatibility,
-  Workspace,
-} from "./workspace.js";
+import { Workspace } from "./workspace.js";
 
 // The remote runtime handle stub: a result / stream / kill surface
 // carried across Workers RPC.
@@ -315,7 +311,7 @@ function withExecutionId(
 // `fs`, `git`, `artifacts`, and `assets` are the underlying surface's
 // members, passed through. The filesystem stub mirrors the local
 // filesystem, so it also serves as the common client type.
-export interface WorkspaceClient extends Partial<ThinkWorkspaceCompatibility> {
+export interface WorkspaceClient {
   readonly fs: WorkspaceFilesystem;
   readonly runtime: WorkspaceRuntimeClient;
   // biome-ignore lint/suspicious/noExplicitAny: git type differs local vs remote
@@ -332,7 +328,6 @@ function makeClient(
   surface: any,
   rehydrate: (handle: unknown, metadata?: RuntimeHandleMetadata) => unknown,
   dispose: () => void,
-  useThink: boolean,
 ): WorkspaceClient {
   const runtime = makeRuntimeClient(
     surface.runtime as UnderlyingRuntime,
@@ -354,7 +349,6 @@ function makeClient(
     },
     [Symbol.dispose]: dispose,
   };
-  if (useThink) Object.assign(client, createThinkCompatibility(client.fs));
   return client;
 }
 
@@ -383,7 +377,6 @@ export async function getWorkspace(handle: WorkspaceHandle): Promise<WorkspaceCl
       // Local handle is already a host ExecHandle — pass it through.
       (h) => h,
       () => {},
-      local.useThink,
     );
   }
   // Remote path: fetch the stub over RPC and delegate to it. Handle
@@ -397,7 +390,6 @@ export async function getWorkspace(handle: WorkspaceHandle): Promise<WorkspaceCl
       () => {
         (stub as { [Symbol.dispose]?: () => void })[Symbol.dispose]?.();
       },
-      await stub.useThink,
     );
   } catch (error) {
     (stub as { [Symbol.dispose]?: () => void })[Symbol.dispose]?.();

--- a/packages/computer/src/index.ts
+++ b/packages/computer/src/index.ts
@@ -99,7 +99,6 @@ export {
   type SyncRetryIntent,
   type SyncRetryOptions,
   type SyncRetryScheduler,
-  type ThinkWorkspaceCompatibility,
   Workspace,
   type WorkspaceGitFactory,
   type WorkspaceOptions,

--- a/packages/computer/src/stub.ts
+++ b/packages/computer/src/stub.ts
@@ -600,7 +600,6 @@ export class WorkspaceStub extends RpcTarget {
   readonly #git: WorkspaceGitStub;
   readonly #assets: WorkspaceAssetsStub | undefined;
   readonly #artifacts: WorkspaceArtifactsStub;
-  readonly #useThink: boolean;
 
   constructor(ws: Workspace) {
     super();
@@ -609,7 +608,6 @@ export class WorkspaceStub extends RpcTarget {
     this.#git = new WorkspaceGitStub(ws);
     this.#assets = ws.assets === undefined ? undefined : new WorkspaceAssetsStub(ws);
     this.#artifacts = new WorkspaceArtifactsStub(ws.artifacts);
-    this.#useThink = ws.useThink;
     trackStub(this);
   }
 
@@ -630,10 +628,6 @@ export class WorkspaceStub extends RpcTarget {
 
   get fs(): WorkspaceFilesystemStub {
     return this.#fs;
-  }
-
-  get useThink(): boolean {
-    return this.#useThink;
   }
 
   get runtime(): WorkspaceRuntimeStub {

--- a/packages/computer/src/workspace.test.ts
+++ b/packages/computer/src/workspace.test.ts
@@ -5,23 +5,10 @@ import type { BackendHandle, WorkspaceBackend } from "./backend.js";
 import { createGitClient } from "./git/index.js";
 import type { WorkspaceModuleBackend } from "./runtime/types.js";
 import { WorkspaceTransportError } from "./transport-failure.js";
-import { type ThinkWorkspaceCompatibility, Workspace } from "./workspace.js";
+import { Workspace } from "./workspace.js";
 
 function makeStorage(): SQLiteTestStorage {
   return new SQLiteTestStorage();
-}
-
-function expectThinkWorkspace(
-  ws: Workspace,
-): asserts ws is Workspace & ThinkWorkspaceCompatibility {
-  expect(ws).toHaveProperty("readFile");
-  expect(ws).toHaveProperty("readFileBytes");
-  expect(ws).toHaveProperty("writeFile");
-  expect(ws).toHaveProperty("readDir");
-  expect(ws).toHaveProperty("glob");
-  expect(ws).toHaveProperty("mkdir");
-  expect(ws).toHaveProperty("rm");
-  expect(ws).toHaveProperty("stat");
 }
 
 // In-process fakes. We never spawn anything from the package
@@ -1463,49 +1450,15 @@ describe("Workspace transport-failure invalidation", () => {
     ]);
   });
 });
-describe("Workspace Think compatibility", () => {
-  it("adds Think-compatible filesystem methods when useThink is true", async () => {
+describe("Workspace compatibility surface", () => {
+  it("does not accept useThink or add root-level filesystem methods", () => {
     const ws = new Workspace({
       storage: makeStorage(),
+      // @ts-expect-error useThink was removed with the compatibility layer.
       useThink: true,
-      now: () => 1_700_000_000_000,
     });
 
-    expectThinkWorkspace(ws);
-
-    await ws.mkdir("/workspace/notes", { recursive: true });
-    await ws.writeFile("/workspace/notes/a.txt", "hello");
-    await ws.writeFile("/workspace/notes/b.md", "# title");
-
-    expect(await ws.readFile("/workspace/notes/a.txt")).toBe("hello");
-    expect(await ws.readFile("/workspace/missing.txt")).toBeNull();
-    expect(new TextDecoder().decode(await ws.readFileBytes("/workspace/notes/a.txt"))).toBe(
-      "hello",
-    );
-    expect(await ws.readFileBytes("/workspace/missing.txt")).toBeNull();
-
-    await expect(ws.stat("/workspace/notes/a.txt")).resolves.toMatchObject({
-      path: "/workspace/notes/a.txt",
-      name: "a.txt",
-      type: "file",
-      size: 5,
-    });
-    await expect(ws.stat("/workspace/missing.txt")).resolves.toBeNull();
-
-    await expect(ws.readDir("/workspace/notes", { limit: 1, offset: 1 })).resolves.toEqual([
-      expect.objectContaining({ path: "/workspace/notes/b.md", name: "b.md", type: "file" }),
-    ]);
-    await expect(ws.glob("/workspace/notes/**/*.txt")).resolves.toEqual([
-      expect.objectContaining({ path: "/workspace/notes/a.txt", name: "a.txt", type: "file" }),
-    ]);
-
-    await ws.rm("/workspace/notes/a.txt", { force: true });
-    expect(await ws.readFile("/workspace/notes/a.txt")).toBeNull();
-  });
-
-  it("does not add Think compatibility methods by default", () => {
-    const ws = new Workspace({ storage: makeStorage() });
-
+    expect(ws).not.toHaveProperty("useThink");
     expect(ws).not.toHaveProperty("readFile");
     expect(ws).not.toHaveProperty("readFileBytes");
     expect(ws).not.toHaveProperty("writeFile");
@@ -1514,5 +1467,6 @@ describe("Workspace Think compatibility", () => {
     expect(ws).not.toHaveProperty("mkdir");
     expect(ws).not.toHaveProperty("rm");
     expect(ws).not.toHaveProperty("stat");
+    expect(ws.stub()).not.toHaveProperty("useThink");
   });
 });

--- a/packages/computer/src/workspace.ts
+++ b/packages/computer/src/workspace.ts
@@ -149,39 +149,7 @@ export interface WorkspaceOptions {
     binding: Artifacts;
     sessionId?: string;
   };
-
-  // Add Think's string-oriented WorkspaceLike filesystem methods
-  // directly to the Workspace instance. This is off by default so
-  // the primary Workspace API stays on the `workspace.fs` facade;
-  // enable it when assigning a Workspace to `Think.workspace`.
-  useThink?: boolean;
 }
-
-export interface ThinkFileInfo {
-  path: string;
-  name: string;
-  type: "file" | "directory";
-  mimeType: string;
-  size: number;
-  createdAt: number;
-  updatedAt: number;
-}
-
-export interface ThinkWorkspaceCompatibility {
-  readFile(path: string): Promise<string | null>;
-  readFileBytes(path: string): Promise<Uint8Array | null>;
-  writeFile(path: string, content: string): Promise<void>;
-  readDir(dir: string, opts?: { limit?: number; offset?: number }): Promise<ThinkFileInfo[]>;
-  rm(path: string, opts?: { recursive?: boolean; force?: boolean }): Promise<void>;
-  glob(pattern: string): Promise<ThinkFileInfo[]>;
-  mkdir(path: string, opts?: { recursive?: boolean }): Promise<void>;
-  stat(path: string): Promise<ThinkFileInfo | null>;
-}
-
-export type ThinkWorkspaceFilesystem = Pick<
-  WorkspaceFilesystem,
-  "find" | "mkdir" | "readFile" | "readdir" | "rm" | "stat" | "writeFile"
->;
 
 export type WorkspaceGitFactory = GitClientFactory;
 
@@ -222,7 +190,6 @@ export class Workspace {
   readonly #sessionId: string;
   readonly #gitFactory: WorkspaceGitFactory | undefined;
   readonly #defaultGitIdentity: GitIdentity | undefined;
-  readonly #useThink: boolean;
   readonly #assets: AssetsClient | undefined;
   readonly #artifacts: ArtifactClient;
   // Lazily-constructed git client, cached so the dynamic
@@ -258,15 +225,6 @@ export class Workspace {
   // and updates it. See docs/02 "Concurrent mutators".
   readonly #mutationTails = new Map<string, Promise<unknown>>();
 
-  declare readonly readFile?: ThinkWorkspaceCompatibility["readFile"];
-  declare readonly readFileBytes?: ThinkWorkspaceCompatibility["readFileBytes"];
-  declare readonly writeFile?: ThinkWorkspaceCompatibility["writeFile"];
-  declare readonly readDir?: ThinkWorkspaceCompatibility["readDir"];
-  declare readonly rm?: ThinkWorkspaceCompatibility["rm"];
-  declare readonly glob?: ThinkWorkspaceCompatibility["glob"];
-  declare readonly mkdir?: ThinkWorkspaceCompatibility["mkdir"];
-  declare readonly stat?: ThinkWorkspaceCompatibility["stat"];
-
   constructor(options: WorkspaceOptions) {
     this.#now = options.now ?? Date.now;
     this.#retryScheduler = options.retryScheduler;
@@ -288,7 +246,6 @@ export class Workspace {
     this.#sessionId = options.sessionId ?? "";
     this.#gitFactory = options.git;
     this.#defaultGitIdentity = options.defaultGitIdentity;
-    this.#useThink = options.useThink ?? false;
     this.#artifacts = options.artifacts
       ? createArtifact(
           options.artifacts.binding,
@@ -332,10 +289,6 @@ export class Workspace {
       mounts: this.#mounts,
     });
     this.#assets = typeof options.assets === "function" ? options.assets(this) : options.assets;
-    if (this.#useThink) {
-      const think = createThinkCompatibility(this.fs);
-      Object.assign(this, think);
-    }
   }
 
   // Force every registered mount to materialize. Idempotent; safe to
@@ -378,10 +331,6 @@ export class Workspace {
   // also rejected (and surfaced via Workspace.pull's skipped[]).
   get fs(): WorkspaceFilesystem {
     return this.#fs;
-  }
-
-  get useThink(): boolean {
-    return this.#useThink;
   }
 
   // Identifier for this workspace / session, as passed to the
@@ -1060,162 +1009,4 @@ function createDisabledArtifactsClient(): ArtifactClient {
       return runArtifactsCLI(this, input);
     },
   } as ArtifactClient;
-}
-
-export function createThinkCompatibility(
-  fs: ThinkWorkspaceFilesystem,
-): ThinkWorkspaceCompatibility {
-  return {
-    async readFile(path) {
-      try {
-        return await fs.readFile(path, "utf8");
-      } catch (err) {
-        if (isEnoent(err)) return null;
-        throw err;
-      }
-    },
-    async readFileBytes(path) {
-      try {
-        return await drainBytes(await fs.readFile(path));
-      } catch (err) {
-        if (isEnoent(err)) return null;
-        throw err;
-      }
-    },
-    async writeFile(path, content) {
-      await fs.writeFile(path, content);
-    },
-    async readDir(dir, opts) {
-      const entries = await fs.readdir(dir);
-      const offset = opts?.offset ?? 0;
-      const limit = opts?.limit ?? entries.length;
-      return entries.slice(offset, offset + limit).map((entry) =>
-        toThinkFileInfo({
-          path: joinPath(dir, entry.name),
-          name: entry.name,
-          size: 0,
-          mtime: 0,
-          isDirectory: entry.isDirectory,
-          isFile: entry.isFile,
-        }),
-      );
-    },
-    async rm(path, opts) {
-      await fs.rm(path, opts);
-    },
-    async glob(pattern) {
-      const { directory, relativePattern } = splitGlobPattern(pattern);
-      const matches = await fs.find(directory, relativePattern);
-      return matches.map((match) =>
-        toThinkFileInfo({
-          path: match.path,
-          name: basename(match.path),
-          size: 0,
-          mtime: 0,
-          isDirectory: match.type === "dir",
-          isFile: match.type === "file",
-        }),
-      );
-    },
-    async mkdir(path, opts) {
-      await fs.mkdir(path, opts);
-    },
-    async stat(path) {
-      try {
-        const stat = await fs.stat(path);
-        return toThinkFileInfo({ ...stat, path, name: basename(path) });
-      } catch (err) {
-        if (isEnoent(err)) return null;
-        throw err;
-      }
-    },
-  };
-}
-
-async function drainBytes(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
-  const reader = stream.getReader();
-  const parts: Uint8Array[] = [];
-  let total = 0;
-  try {
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      if (!value) continue;
-      parts.push(value);
-      total += value.byteLength;
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  if (parts.length === 1) return parts[0];
-  const out = new Uint8Array(total);
-  let offset = 0;
-  for (const part of parts) {
-    out.set(part, offset);
-    offset += part.byteLength;
-  }
-  return out;
-}
-
-function toThinkFileInfo(input: {
-  path: string;
-  name: string;
-  size: number;
-  mtime: number;
-  isDirectory: boolean;
-  isFile: boolean;
-}): ThinkFileInfo {
-  const type = input.isDirectory ? "directory" : "file";
-  return {
-    path: input.path,
-    name: input.name,
-    type,
-    mimeType: type === "directory" ? "inode/directory" : "application/octet-stream",
-    size: input.size,
-    createdAt: input.mtime,
-    updatedAt: input.mtime,
-  };
-}
-
-function splitGlobPattern(pattern: string): { directory: string; relativePattern?: string } {
-  const normalized = pattern.startsWith("/") ? pattern : `/workspace/${pattern}`;
-  const wildcard = firstWildcardIndex(normalized);
-  if (wildcard === -1) {
-    return { directory: dirname(normalized), relativePattern: basename(normalized) };
-  }
-  const slash = normalized.lastIndexOf("/", wildcard);
-  const directory = slash <= 0 ? "/" : normalized.slice(0, slash);
-  const relativePattern = normalized.slice(slash + 1);
-  return { directory, relativePattern };
-}
-
-function firstWildcardIndex(pattern: string): number {
-  const star = pattern.indexOf("*");
-  const question = pattern.indexOf("?");
-  if (star === -1) return question;
-  if (question === -1) return star;
-  return Math.min(star, question);
-}
-
-function joinPath(dir: string, name: string): string {
-  return dir === "/" ? `/${name}` : `${dir}/${name}`;
-}
-
-function dirname(path: string): string {
-  const index = path.lastIndexOf("/");
-  if (index <= 0) return "/";
-  return path.slice(0, index);
-}
-
-function basename(path: string): string {
-  const trimmed = path.endsWith("/") && path !== "/" ? path.slice(0, -1) : path;
-  const index = trimmed.lastIndexOf("/");
-  return index === -1 ? trimmed : trimmed.slice(index + 1);
-}
-
-function isEnoent(err: unknown): boolean {
-  if (!err || typeof err !== "object") return false;
-  const e = err as { code?: string; message?: string };
-  if (e.code === "ENOENT") return true;
-  return typeof e.message === "string" && /ENOENT|no such/i.test(e.message);
 }


### PR DESCRIPTION
*Stack 6 of 7. Base: `stack/improve-tools-05-document-tools`. Head: `stack/improve-tools-06-remove-think-compat`.*

Computer carried a second, root-level filesystem API solely for older Think integrations. It duplicated `workspace.fs`, added conditional methods to `Workspace` and `WorkspaceClient`, and sent a compatibility flag across Workers RPC.

This breaking change removes `WorkspaceOptions.useThink`, the root-level adapters, their public types and helpers, and the RPC flag. `getWorkspace()` now exposes one filesystem surface and no longer inspects remote compatibility state. Regression tests verify that `Workspace`, `WorkspaceStub`, and local or remote clients do not recreate the removed API. A separate changeset calls out the migration to `workspace.fs` and `@cloudflare/computer/tools`.

**Verification**

```sh
npm run typecheck --workspace @cloudflare/computer
npm test --workspace @cloudflare/computer
```

This part depends on the corresponding Think migration being released first. The final stack part updates this repository's Think consumers and documentation.
