### PR TITLE
Ensure all tests run on CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
             workspace: "@cloudflare/dofs"
             path: packages/dofs
             needs-siblings: false
+            extra-test: "test:workers"
           - name: rpc
             workspace: "@cloudflare/computer-rpc"
             path: packages/rpc
@@ -57,14 +58,19 @@ jobs:
             workspace: "@cloudflare/computer"
             path: packages/computer
             needs-siblings: true
+            build-computerd-bin: true
+            extra-test: "test:harness"
+            system-deps: "fuse3 xz-utils"
           - name: computerd
             workspace: "@cloudflare/computerd"
             path: packages/computerd
             needs-siblings: true
+            build-computerd-bin: true
             # libfuse2 (libfuse.so.2) is what fuse-native binds to at
             # runtime; fuse3 ships /dev/fuse helpers and the
             # FUSE_MOUNT=shim tests need it for the userspace mount path.
-            system-deps: "libfuse2t64 fuse3"
+            # xz-utils extracts the target Node binary used by build:bin.
+            system-deps: "libfuse2t64 fuse3 xz-utils"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -77,6 +83,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ${{ matrix.system-deps }}
+
+      - name: Prepare Docker and FUSE
+        if: matrix.build-computerd-bin
+        run: |
+          docker info
+          sudo modprobe fuse
+          sudo chmod a+rw /dev/fuse
 
       # Build every npm workspace's dist/ unconditionally for now. The
       # computer + computerd jobs need dofs + rpc dist, the rpc job needs
@@ -91,6 +104,13 @@ jobs:
         if: matrix.needs-siblings == false
         run: npm run build --workspace ${{ matrix.workspace }} --if-present
 
+      # The computer harness and computerd's real-FUSE regression both
+      # discover the standalone binary at artifacts/computerd/. Building it
+      # makes those suites execute instead of silently skipping.
+      - name: Build computerd binary
+        if: matrix.build-computerd-bin
+        run: npm run build:bin --workspace @cloudflare/computerd
+
       - name: Lint + format check
         run: npx biome check ${{ matrix.path }}
 
@@ -100,6 +120,10 @@ jobs:
       - name: Test
         run: npm test --workspace ${{ matrix.workspace }} --if-present
 
+      - name: Test (${{ matrix.extra-test }})
+        if: matrix.extra-test
+        run: npm run ${{ matrix.extra-test }} --workspace ${{ matrix.workspace }}
+
   example:
     name: example/${{ matrix.name }}
     runs-on: ubuntu-24.04
@@ -108,12 +132,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: think
-            workspace: "@cloudflare/example-think"
-            path: examples/think
+          - name: artifacts
+            workspace: "@example/computer-artifacts"
+            path: examples/artifacts
+            typegen: "npx wrangler types"
+          - name: assets
+            workspace: "@example/computer-assets"
+            path: examples/assets
           - name: container
             workspace: "@example/computer-container"
             path: examples/container
+            typegen: "npx wrangler types"
+          - name: think
+            workspace: "@cloudflare/example-think"
+            path: examples/think
+            typegen: "npx wrangler types"
+          - name: think-compare-runtimes
+            workspace: "@cloudflare/example-think-compare-runtimes"
+            path: examples/think-compare-runtimes
+          - name: tutorial
+            workspace: "@example/computer-tutorial"
+            path: examples/tutorial
+            typegen: "npm run build:types"
+          - name: worker-javascript
+            workspace: "@example/computer-worker-javascript"
+            path: examples/worker-javascript
+          - name: worker-shell
+            workspace: "@example/computer-worker-shell"
+            path: examples/worker-shell
     steps:
       - uses: actions/checkout@v6
         with:
@@ -127,7 +173,8 @@ jobs:
       - run: npm run build --workspaces --if-present
 
       - name: Generate worker types
-        run: npx wrangler types
+        if: matrix.typegen
+        run: ${{ matrix.typegen }}
         working-directory: ${{ matrix.path }}
 
       - name: Lint + format check
@@ -136,8 +183,8 @@ jobs:
       - name: Typecheck
         run: npm run typecheck --workspace ${{ matrix.workspace }} --if-present
 
-      # Examples don't ship tests today; --if-present makes this a
-      # no-op until they do.
+      # Most examples don't ship tests today; --if-present keeps this a
+      # no-op for them while running suites such as think-compare-runtimes.
       - name: Test
         run: npm test --workspace ${{ matrix.workspace }} --if-present
 

--- a/packages/computer/src/test-harness/shell.test.ts
+++ b/packages/computer/src/test-harness/shell.test.ts
@@ -85,7 +85,7 @@ describeIfDocker("Workspace.shell against a real computerd container", () => {
           const { value, done } = await reader.read();
           if (done) break;
           if (value.name === "stdout") chunks.push(value.value);
-          else if (value.name === "exit") exitCode = value.value;
+          else if (value.name === "exit") exitCode = value.code;
         }
       } finally {
         reader.releaseLock();

--- a/packages/dofs/src/fs/filesystem.test.ts
+++ b/packages/dofs/src/fs/filesystem.test.ts
@@ -9,24 +9,14 @@
 
 import { describe, expect, it } from "vitest";
 
-import { initializeSchema } from "../schema/index.js";
-import { Database } from "../storage.js";
-import { SQLiteTestStorage } from "../testing.js";
 import { WorkspaceFilesystem } from "./filesystem.js";
+import { withDB } from "./with-db.js";
 
 async function withFs<T>(
   fn: (fs: WorkspaceFilesystem) => T | Promise<T>,
   now: () => number = () => 1234,
 ): Promise<T> {
-  const storage = new SQLiteTestStorage();
-  const db = new Database(storage);
-  initializeSchema(db, now);
-  const fs = new WorkspaceFilesystem(db, { now });
-  try {
-    return await fn(fs);
-  } finally {
-    storage.close();
-  }
+  return withDB((db) => fn(new WorkspaceFilesystem(db, { now })), { now });
 }
 
 describe("WorkspaceFilesystem", () => {

--- a/packages/dofs/src/sync/fetch.test.ts
+++ b/packages/dofs/src/sync/fetch.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { withDB } from "../fs/with-db.js";
 import { chunksOf, createFileSync, writeFile, writeRangeSync } from "../fs/writeFile.js";
-import { initializeSchema } from "../schema/index.js";
 import { Database } from "../storage.js";
-import { SQLiteTestStorage } from "../testing.js";
 import type { DurableObjectStorageLike, SQLCursorLike } from "../types.js";
 import { stageBlob } from "./blobs.js";
 import { coalesceChanges } from "./coalesce.js";
@@ -134,34 +132,30 @@ describe("hasObjects", () => {
     });
   });
 
-  it("probes more objects than Durable Object SQLite accepts in one query", () => {
-    const storage = new SQLiteTestStorage();
-    const limitedStorage: DurableObjectStorageLike = {
-      sql: {
-        exec<Row extends object>(query: string, ...bindings: unknown[]): SQLCursorLike<Row> {
-          if (bindings.length > 100) {
-            throw new Error(`too many SQLite bindings: ${bindings.length}`);
-          }
-          return storage.sql.exec<Row>(query, ...bindings);
+  it("probes more objects than Durable Object SQLite accepts in one query", async () => {
+    await withDB((db) => {
+      const limitedStorage: DurableObjectStorageLike = {
+        sql: {
+          exec<Row extends object>(query: string, ...bindings: unknown[]): SQLCursorLike<Row> {
+            if (bindings.length > 100) {
+              throw new Error(`too many SQLite bindings: ${bindings.length}`);
+            }
+            return db.sql.exec<Row>(query, ...bindings);
+          },
         },
-      },
-      transactionSync: (closure) => storage.transactionSync(closure),
-    };
-    const db = new Database(limitedStorage);
-    initializeSchema(db, () => 1000);
-    try {
+        transactionSync: (closure) => db.transactionSync(closure),
+      };
+      const limitedDb = new Database(limitedStorage);
       const hashes: Uint8Array[] = [];
       for (let i = 0; i < 101; i++) {
         const bytes = new TextEncoder().encode(`object-${i}`);
         const hash = chunksOf(bytes)[0].hash;
-        stageBlob(db, hash, bytes, i);
+        stageBlob(limitedDb, hash, bytes, i);
         hashes.push(hash);
       }
 
-      expect(hasObjects(db, hashes)).toEqual(hashes);
-    } finally {
-      storage.close();
-    }
+      expect(hasObjects(limitedDb, hashes)).toEqual(hashes);
+    });
   });
 
   it("preserves input order and duplicates across mixed inputs", async () => {

--- a/packages/dofs/vitest.config.workers.ts
+++ b/packages/dofs/vitest.config.workers.ts
@@ -24,12 +24,13 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["src/**/*.test.ts"],
-    // testing.test.ts exercises SQLiteTestStorage directly — the
-    // node:sqlite-backed fixture has no analogue under workerd, so
-    // the test is meaningful only against the real node runtime.
-    // All other tests run under both backends; provider/provider-fd
-    // use a withProvider helper that delegates to withDB, which the
-    // workers config aliases to a DO-backed implementation.
-    exclude: ["src/testing.test.ts"],
+    // These files exercise SQLiteTestStorage directly. The
+    // node:sqlite-backed fixture has no analogue under workerd and
+    // importing it crashes the pool worker instead of reporting a
+    // module-resolution error. schema/index.test.ts also stages raw,
+    // pre-migration databases, which withDB cannot represent.
+    // All other tests run under both backends; helpers delegate to
+    // withDB, which this config aliases to a DO-backed implementation.
+    exclude: ["src/schema/index.test.ts", "src/testing.test.ts"],
   },
 });


### PR DESCRIPTION
Closes #71.

Continuous integration only ran the Node-backed `@cloudflare/dofs` tests. The workerd suite was also red because three tests loaded the Node-only `SQLiteTestStorage` fixture, which crashes the pool worker. Other gaps included the computer Docker harness, computerd's real-FUSE regression, the `think-compare-runtimes` tests, and six example workspaces.

Portable dofs tests now use the existing `withDB` helper, while the Node fixture and raw migration tests remain excluded from workerd. Continuous integration now runs the workerd suite, builds the computerd binary, requires Docker and FUSE for container tests, runs the computer harness, and checks every example workspace. Enabling the harness also exposed and fixed an assertion that read an exit event's old `value` field instead of `code`.

Verify the change with:

```sh
npm run build --workspaces --if-present
npm run build:bin --workspace @cloudflare/computerd
npm test --workspace @cloudflare/dofs
npm run test:workers --workspace @cloudflare/dofs
npm test --workspace @cloudflare/computerd
npm run test:harness --workspace @cloudflare/computer
npm run typecheck
npm run check
```

The Node-backed dofs suite passes 437 tests, the workerd suite passes 426 tests, the Docker harness passes 10 tests, the computerd suite passes 139 tests including the real-FUSE regression, and `think-compare-runtimes` passes 121 tests. All eight examples pass lint and type checks.

Benchmarks and long-running soak scripts remain manual because they are not stable pull request gates.
