### PR TITLE
Fix reported symlink issues

### DIFF
--- a/.changeset/dofs-symlink-fixes.md
+++ b/.changeset/dofs-symlink-fixes.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/dofs": patch
+---
+
+Fix symlink path resolution and write behavior. Relative symlink targets now resolve from the symlink parent, writes follow symlinked parent directories, and writes to final symlinks update or create the target file instead of storing chunks on the symlink node.

--- a/packages/computerd/src/fuse/driver.test.ts
+++ b/packages/computerd/src/fuse/driver.test.ts
@@ -199,6 +199,31 @@ test("FUSE ops return errno values instead of throwing for expected filesystem e
   expect(await status((cb) => ops.unlink("/missing", cb))).toBe(-2);
 });
 
+test("FUSE maps read-only provider mutations to EROFS", async () => {
+  const { vfs } = await createNodeVirtualFileSystem();
+  vfs.writeFileSync("/readonly.txt", Buffer.from("content"));
+  const throwReadOnly = () => {
+    throw Object.assign(new Error("read-only mount"), { code: "EROFS" });
+  };
+  const readOnlyVfs = Object.assign(vfs, {
+    createFileSync: () => undefined,
+    writeRangeSync: throwReadOnly,
+    truncateFileSync: throwReadOnly,
+    openWriteBufferSync: () => undefined,
+    releaseWriteBufferSync: throwReadOnly,
+  });
+  const ops = makeFUSEOps(readOnlyVfs);
+
+  const opened = await callback((cb) => ops.open("/readonly.txt", 0, cb));
+  expect(opened.errno).toBe(0);
+  const fh = opened.result as number;
+  expect(await status((cb) => ops.write("/readonly.txt", fh, Buffer.from("x"), 1, 0, cb))).toBe(
+    -30,
+  );
+  expect(await status((cb) => ops.truncate("/readonly.txt", 0, cb))).toBe(-30);
+  expect(await status((cb) => ops.release("/readonly.txt", fh, cb))).toBe(-30);
+});
+
 test("FUSE unlink removes a symlink itself rather than its target", async () => {
   const { vfs } = await createNodeVirtualFileSystem();
   const ops = makeFUSEOps(vfs);

--- a/packages/computerd/src/fuse/driver.ts
+++ b/packages/computerd/src/fuse/driver.ts
@@ -14,6 +14,7 @@ const ERRNO = {
   EINVAL: -22,
   EPERM: -1,
   EFBIG: -27,
+  EROFS: -30,
   ENOTEMPTY: -39,
   ENODATA: -61,
   ENOSYS: -38,
@@ -1088,5 +1089,6 @@ function toErrno(error: unknown): number {
   if (code === "ENOTEMPTY") return ERRNO.ENOTEMPTY;
   if (code === "EINVAL") return ERRNO.EINVAL;
   if (code === "EPERM") return ERRNO.EPERM;
+  if (code === "EROFS") return ERRNO.EROFS;
   return ERRNO.EIO;
 }

--- a/packages/dofs/src/fs/mount-guard.test.ts
+++ b/packages/dofs/src/fs/mount-guard.test.ts
@@ -180,6 +180,18 @@ describe("writeFile under a read-only mount", () => {
     });
   });
 
+  it("allows opening and releasing a file inside a read-only mount without writing", async () => {
+    await withDB((db) => {
+      mkdir(db, "/mnt", {}, () => 0);
+      writeFileSync(db, "/mnt/file.txt", new Uint8Array([1]), {}, () => 0);
+      stageMount(db, "/mnt", "read-only");
+
+      expect(() => openWriteBufferSync(db, "/mnt/file.txt")).not.toThrow();
+      expect(() => releaseWriteBufferSync(db, "/mnt/file.txt", () => 1)).not.toThrow();
+      expect(resolveInode(db, "/mnt/file.txt")?.type).toBe("file");
+    });
+  });
+
   it("rejects streaming writes through a symlinked parent before staging blobs", async () => {
     await withDB(async (db) => {
       mkdir(db, "/mnt", {}, () => 0);
@@ -279,9 +291,8 @@ describe("writeFile under a read-only mount", () => {
       openWriteBufferForCreateSync(db, "/linkdir/new.txt", {}, () => 0);
       stageMount(db, "/linkdir", "read-only");
 
-      expect(() => openWriteBufferSync(db, "/linkdir/new.txt")).toThrowError(
-        expect.objectContaining({ code: "EROFS" }),
-      );
+      expect(() => openWriteBufferSync(db, "/linkdir/new.txt")).not.toThrow();
+      expect(() => releaseWriteBufferSync(db, "/linkdir/new.txt", () => 1)).not.toThrow();
       expect(() => releaseWriteBufferSync(db, "/linkdir/new.txt", () => 1)).toThrowError(
         expect.objectContaining({ code: "EROFS" }),
       );

--- a/packages/dofs/src/fs/mount-guard.test.ts
+++ b/packages/dofs/src/fs/mount-guard.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import type { Database } from "../storage.js";
 import { stageBlob } from "../sync/blobs.js";
+import { link } from "./link.js";
 import { mkdir } from "./mkdir.js";
 import {
   assertNotReadOnly,
@@ -190,6 +191,24 @@ describe("writeFile under a read-only mount", () => {
       expect(() => openWriteBufferSync(db, "/mnt/file.txt")).not.toThrow();
       expect(() => releaseWriteBufferSync(db, "/mnt/file.txt", () => 1)).not.toThrow();
       expect(resolveInode(db, "/mnt/file.txt")?.type).toBe("file");
+    });
+  });
+
+  it("commits writable hardlink mutations when a read-only alias closes last", async () => {
+    await withDB((db) => {
+      mkdir(db, "/mnt", {}, () => 0);
+      writeFileSync(db, "/outside.txt", new TextEncoder().encode("seed"), {}, () => 0);
+      link(db, "/outside.txt", "/mnt/file.txt");
+      stageMount(db, "/mnt", "read-only");
+
+      openWriteBufferSync(db, "/outside.txt");
+      openWriteBufferSync(db, "/mnt/file.txt");
+      writeRangeSync(db, "/outside.txt", new TextEncoder().encode("done"), 0, {}, () => 1);
+      releaseWriteBufferSync(db, "/outside.txt", () => 2);
+      expect(() => releaseWriteBufferSync(db, "/mnt/file.txt", () => 2)).not.toThrow();
+
+      expect(new TextDecoder().decode(readRangeSync(db, "/outside.txt", 0, 4))).toBe("done");
+      expect(new TextDecoder().decode(readRangeSync(db, "/mnt/file.txt", 0, 4))).toBe("done");
     });
   });
 

--- a/packages/dofs/src/fs/mount-guard.test.ts
+++ b/packages/dofs/src/fs/mount-guard.test.ts
@@ -110,6 +110,16 @@ describe("mount-guard helpers", () => {
     });
   });
 
+  it("treats every path as a descendant of a read-only root mount", async () => {
+    await withDB((db) => {
+      stageMount(db, "/", "read-only");
+
+      expect(() => assertNotReadOnly(db, "/child")).toThrowError(
+        expect.objectContaining({ code: "EROFS" }),
+      );
+    });
+  });
+
   it("read-write mounts do not register as read-only", async () => {
     await withDB(async (db) => {
       stageMount(db, "/workspace/rw", "read-write");
@@ -120,6 +130,21 @@ describe("mount-guard helpers", () => {
 });
 
 describe("writeFile under a read-only mount", () => {
+  it("rejects direct and symlinked writes under a read-only root mount", async () => {
+    await withDB((db) => {
+      mkdir(db, "/actual", {}, () => 0);
+      symlink(db, "/actual", "/link", () => 0);
+      stageMount(db, "/", "read-only");
+
+      expect(() => writeFileSync(db, "/direct.txt", new Uint8Array([1]), {}, () => 0)).toThrowError(
+        expect.objectContaining({ code: "EROFS" }),
+      );
+      expect(() =>
+        writeFileSync(db, "/link/through.txt", new Uint8Array([1]), {}, () => 0),
+      ).toThrowError(expect.objectContaining({ code: "EROFS" }));
+    });
+  });
+
   it("rejects a streaming write under the mount root with EROFS", async () => {
     await withDB(async (db) => {
       // Materialise the directory before flipping the mount to

--- a/packages/dofs/src/fs/mount-guard.test.ts
+++ b/packages/dofs/src/fs/mount-guard.test.ts
@@ -15,7 +15,18 @@ import { resolveInode } from "./resolve.js";
 import { rm } from "./rm.js";
 import { symlink } from "./symlink.js";
 import { withDB } from "./with-db.js";
-import { linkStagedChunksSync, writeFile, writeFileSync } from "./writeFile.js";
+import {
+  createFileSync,
+  linkStagedChunksSync,
+  openWriteBufferForCreateSync,
+  openWriteBufferSync,
+  releaseWriteBufferSync,
+  truncateFileSync,
+  writeFile,
+  writeFileRangesSync,
+  writeFileSync,
+  writeRangeSync,
+} from "./writeFile.js";
 
 // Stage a read-only mount the way the workspace-side indexer
 // eventually will: a row in `_vfs_mounts` plus an actual subtree
@@ -144,6 +155,145 @@ describe("writeFile under a read-only mount", () => {
     });
   });
 
+  it("rejects streaming writes through a symlinked parent before staging blobs", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/mnt", {}, () => 0);
+      symlink(db, "/mnt", "/linkdir", () => 0);
+      stageMount(db, "/mnt", "read-only");
+      let pulls = 0;
+      const source = new ReadableStream<Uint8Array>(
+        {
+          pull(controller) {
+            pulls += 1;
+            controller.enqueue(new Uint8Array([1]));
+            controller.close();
+          },
+        },
+        { highWaterMark: 0 },
+      );
+
+      await expect(writeFile(db, "/linkdir/new.txt", source, {}, () => 0)).rejects.toMatchObject({
+        code: "EROFS",
+      });
+      expect(pulls).toBe(0);
+      expect(db.scalar<number>("SELECT COUNT(*) FROM vfs_blobs")).toBe(0);
+    });
+  });
+
+  it("rejects writeFileSync through a symlinked parent into a read-only mount", async () => {
+    await withDB((db) => {
+      mkdir(db, "/mnt", {}, () => 0);
+      symlink(db, "/mnt", "/linkdir", () => 0);
+      stageMount(db, "/mnt", "read-only");
+
+      expect(() =>
+        writeFileSync(db, "/linkdir/new.txt", new Uint8Array([1]), {}, () => 0),
+      ).toThrowError(expect.objectContaining({ code: "EROFS" }));
+      expect(resolveInode(db, "/mnt/new.txt")).toBeNull();
+    });
+  });
+
+  it("rejects a final symlink target that escapes a read-only mount", async () => {
+    await withDB((db) => {
+      mkdir(db, "/mnt", {}, () => 0);
+      mkdir(db, "/outside", {}, () => 0);
+      symlink(db, "/outside", "/mnt/escape", () => 0);
+      symlink(db, "/mnt/escape/file.txt", "/entry", () => 0);
+      stageMount(db, "/mnt", "read-only");
+
+      expect(() => writeFileSync(db, "/entry", new Uint8Array([1]), {}, () => 0)).toThrowError(
+        expect.objectContaining({ code: "EROFS" }),
+      );
+      expect(resolveInode(db, "/outside/file.txt")).toBeNull();
+    });
+  });
+
+  it("rejects an intermediate symlink target that escapes a read-only mount", async () => {
+    await withDB((db) => {
+      mkdir(db, "/mnt", {}, () => 0);
+      mkdir(db, "/outside", {}, () => 0);
+      symlink(db, "/outside", "/mnt/escape", () => 0);
+      symlink(db, "/mnt/escape", "/entry", () => 0);
+      stageMount(db, "/mnt", "read-only");
+
+      expect(() =>
+        writeFileSync(db, "/entry/file.txt", new Uint8Array([1]), {}, () => 0),
+      ).toThrowError(expect.objectContaining({ code: "EROFS" }));
+      expect(resolveInode(db, "/outside/file.txt")).toBeNull();
+    });
+  });
+
+  it("rejects file creation through a symlinked parent into a read-only mount", async () => {
+    await withDB((db) => {
+      mkdir(db, "/mnt", {}, () => 0);
+      symlink(db, "/mnt", "/linkdir", () => 0);
+      stageMount(db, "/mnt", "read-only");
+
+      expect(() => createFileSync(db, "/linkdir/new.txt", {}, () => 0)).toThrowError(
+        expect.objectContaining({ code: "EROFS" }),
+      );
+    });
+  });
+
+  it("rejects buffered creation through a symlinked parent into a read-only mount", async () => {
+    await withDB((db) => {
+      mkdir(db, "/mnt", {}, () => 0);
+      symlink(db, "/mnt", "/linkdir", () => 0);
+      stageMount(db, "/mnt", "read-only");
+
+      expect(() => openWriteBufferForCreateSync(db, "/linkdir/new.txt", {}, () => 0)).toThrowError(
+        expect.objectContaining({ code: "EROFS" }),
+      );
+    });
+  });
+
+  it("rechecks the lexical path when a pending create is released", async () => {
+    await withDB((db) => {
+      mkdir(db, "/actual", {}, () => 0);
+      symlink(db, "/actual", "/linkdir", () => 0);
+      openWriteBufferForCreateSync(db, "/linkdir/new.txt", {}, () => 0);
+      stageMount(db, "/linkdir", "read-only");
+
+      expect(() => openWriteBufferSync(db, "/linkdir/new.txt")).toThrowError(
+        expect.objectContaining({ code: "EROFS" }),
+      );
+      expect(() => releaseWriteBufferSync(db, "/linkdir/new.txt", () => 1)).toThrowError(
+        expect.objectContaining({ code: "EROFS" }),
+      );
+      expect(resolveInode(db, "/actual/new.txt")).toBeNull();
+    });
+  });
+
+  it.each([
+    [
+      "whole-file range write",
+      (db: Database) =>
+        writeFileRangesSync(
+          db,
+          "/linkdir/file.txt",
+          new TextEncoder().encode("new"),
+          [{ start: 0, end: 3 }],
+          {},
+          () => 1,
+        ),
+    ],
+    [
+      "positional write",
+      (db: Database) =>
+        writeRangeSync(db, "/linkdir/file.txt", new Uint8Array([1]), 0, {}, () => 1),
+    ],
+    ["truncate", (db: Database) => truncateFileSync(db, "/linkdir/file.txt", 0, () => 1)],
+  ])("rejects %s through a symlinked parent into a read-only mount", async (_name, write) => {
+    await withDB((db) => {
+      mkdir(db, "/mnt", {}, () => 0);
+      writeFileSync(db, "/mnt/file.txt", new TextEncoder().encode("old"), {}, () => 0);
+      symlink(db, "/mnt", "/linkdir", () => 0);
+      stageMount(db, "/mnt", "read-only");
+
+      expect(() => write(db)).toThrowError(expect.objectContaining({ code: "EROFS" }));
+    });
+  });
+
   it("rejects linkStagedChunksSync under the mount root with EROFS", async () => {
     await withDB(async (db) => {
       mkdir(db, "/workspace/r2", { recursive: true }, () => 0);
@@ -164,6 +314,29 @@ describe("writeFile under a read-only mount", () => {
         ),
       ).toThrow(/EROFS|read-only/);
       expect(resolveInode(db, "/workspace/r2/hello.txt")).toBeNull();
+    });
+  });
+
+  it("rejects staged writes through a symlinked parent into a read-only mount", async () => {
+    await withDB((db) => {
+      mkdir(db, "/mnt", {}, () => 0);
+      symlink(db, "/mnt", "/linkdir", () => 0);
+      stageMount(db, "/mnt", "read-only");
+      const bytes = new TextEncoder().encode("blocked");
+      const hash = new Uint8Array(createHash("sha256").update(bytes).digest());
+      stageBlob(db, hash, bytes, 0);
+
+      expect(() =>
+        linkStagedChunksSync(
+          db,
+          "/linkdir/new.txt",
+          ["linkdir", "new.txt"],
+          [{ hash, size: bytes.byteLength }],
+          {},
+          0,
+        ),
+      ).toThrowError(expect.objectContaining({ code: "EROFS" }));
+      expect(resolveInode(db, "/mnt/new.txt")).toBeNull();
     });
   });
 

--- a/packages/dofs/src/fs/mount-guard.test.ts
+++ b/packages/dofs/src/fs/mount-guard.test.ts
@@ -340,6 +340,18 @@ describe("writeFile under a read-only mount", () => {
     });
   });
 
+  it("allows writes through a symlink to a directory that contains a read-only mount", async () => {
+    await withDB((db) => {
+      mkdir(db, "/workspace/scratch", { recursive: true }, () => 0);
+      symlink(db, "/workspace", "/link", () => 0);
+      stageMount(db, "/workspace/r2", "read-only");
+
+      writeFileSync(db, "/link/scratch/file.txt", new Uint8Array([1]), {}, () => 0);
+
+      expect(resolveInode(db, "/workspace/scratch/file.txt")?.type).toBe("file");
+    });
+  });
+
   it("allows writes under a read-write mount", async () => {
     await withDB(async (db) => {
       mkdir(db, "/workspace/rw", { recursive: true }, () => 0);

--- a/packages/dofs/src/fs/mount-guard.test.ts
+++ b/packages/dofs/src/fs/mount-guard.test.ts
@@ -10,6 +10,7 @@ import {
   getReadOnlyMountRoots,
   invalidateReadOnlyMountCache,
 } from "./mount-guard.js";
+import { readRangeSync } from "./readFile.js";
 import { rename } from "./rename.js";
 import { resolveInode } from "./resolve.js";
 import { rm } from "./rm.js";
@@ -189,6 +190,23 @@ describe("writeFile under a read-only mount", () => {
       expect(() => openWriteBufferSync(db, "/mnt/file.txt")).not.toThrow();
       expect(() => releaseWriteBufferSync(db, "/mnt/file.txt", () => 1)).not.toThrow();
       expect(resolveInode(db, "/mnt/file.txt")?.type).toBe("file");
+    });
+  });
+
+  it("evicts rejected dirty bytes before a later read-only open", async () => {
+    await withDB((db) => {
+      mkdir(db, "/mnt", {}, () => 0);
+      writeFileSync(db, "/mnt/file.txt", new TextEncoder().encode("original"), {}, () => 0);
+      openWriteBufferSync(db, "/mnt/file.txt");
+      writeRangeSync(db, "/mnt/file.txt", new TextEncoder().encode("dirty"), 0, {}, () => 1);
+      stageMount(db, "/mnt", "read-only");
+
+      expect(() => releaseWriteBufferSync(db, "/mnt/file.txt", () => 2)).toThrowError(
+        expect.objectContaining({ code: "EROFS" }),
+      );
+      expect(new TextDecoder().decode(readRangeSync(db, "/mnt/file.txt", 0, 8))).toBe("original");
+      expect(() => openWriteBufferSync(db, "/mnt/file.txt")).not.toThrow();
+      expect(() => releaseWriteBufferSync(db, "/mnt/file.txt", () => 3)).not.toThrow();
     });
   });
 

--- a/packages/dofs/src/fs/mount-guard.ts
+++ b/packages/dofs/src/fs/mount-guard.ts
@@ -52,7 +52,7 @@ export function getReadOnlyMountRoots(db: Database): readonly string[] {
 // vectors. Mirrors the predicate that lived in
 // GuardedWorkspaceFilesystem before the data-layer move.
 function isAtOrBelowRoot(path: string, root: string): boolean {
-  return path === root || path.startsWith(`${root}/`);
+  return root === "/" || path === root || path.startsWith(`${root}/`);
 }
 
 function overlapsRoot(path: string, root: string): boolean {

--- a/packages/dofs/src/fs/mount-guard.ts
+++ b/packages/dofs/src/fs/mount-guard.ts
@@ -51,8 +51,12 @@ export function getReadOnlyMountRoots(db: Database): readonly string[] {
 // Both shapes must be blocked so a read-only mount survives both
 // vectors. Mirrors the predicate that lived in
 // GuardedWorkspaceFilesystem before the data-layer move.
+function isAtOrBelowRoot(path: string, root: string): boolean {
+  return path === root || path.startsWith(`${root}/`);
+}
+
 function overlapsRoot(path: string, root: string): boolean {
-  return path === root || path.startsWith(`${root}/`) || root.startsWith(`${path}/`);
+  return isAtOrBelowRoot(path, root) || root.startsWith(`${path}/`);
 }
 
 // Throws EROFS when the path overlaps any read-only mount root.
@@ -64,6 +68,18 @@ export function assertNotReadOnly(db: Database, path: string): void {
   if (roots.length === 0) return;
   for (const root of roots) {
     if (overlapsRoot(path, root)) {
+      throw createWorkspaceError("EROFS", `read-only mount at ${root}: cannot modify`, path);
+    }
+  }
+}
+
+// Point writes only need to reject paths at or below a read-only root.
+// Unlike recursive removal, walking through an ancestor of a mount does
+// not modify the protected subtree.
+export function assertNotInReadOnlyMount(db: Database, path: string): void {
+  const roots = getReadOnlyMountRoots(db);
+  for (const root of roots) {
+    if (isAtOrBelowRoot(path, root)) {
       throw createWorkspaceError("EROFS", `read-only mount at ${root}: cannot modify`, path);
     }
   }

--- a/packages/dofs/src/fs/pendingWriteBuffer.ts
+++ b/packages/dofs/src/fs/pendingWriteBuffer.ts
@@ -4,10 +4,13 @@ import { resolveInode } from "./resolve.js";
 import {
   getPendingWriteBufferByParent,
   getPendingWriteBufferByPath,
+  hasPendingWriteBuffers,
   type WriteBufferEntry,
 } from "./writeBuffer.js";
 
 export function findPendingWriteBuffer(db: Database, path: string): WriteBufferEntry | undefined {
+  if (!hasPendingWriteBuffers(db)) return undefined;
+
   const { parts, path: canonical } = canonicalizePath(path);
   const direct = getPendingWriteBufferByPath(db, canonical);
   if (direct !== undefined || parts.length === 0) return direct;

--- a/packages/dofs/src/fs/pendingWriteBuffer.ts
+++ b/packages/dofs/src/fs/pendingWriteBuffer.ts
@@ -1,0 +1,21 @@
+import { canonicalizePath } from "../path.js";
+import type { Database } from "../storage.js";
+import { resolveInode } from "./resolve.js";
+import {
+  getPendingWriteBufferByParent,
+  getPendingWriteBufferByPath,
+  type WriteBufferEntry,
+} from "./writeBuffer.js";
+
+export function findPendingWriteBuffer(db: Database, path: string): WriteBufferEntry | undefined {
+  const { parts, path: canonical } = canonicalizePath(path);
+  const direct = getPendingWriteBufferByPath(db, canonical);
+  if (direct !== undefined || parts.length === 0) return direct;
+
+  const leafName = parts.at(-1);
+  if (leafName === undefined) return undefined;
+  const parentPath = parts.length === 1 ? "/" : `/${parts.slice(0, -1).join("/")}`;
+  const parent = resolveInode(db, parentPath);
+  if (parent?.type !== "dir") return undefined;
+  return getPendingWriteBufferByParent(db, parent.inode, leafName);
+}

--- a/packages/dofs/src/fs/readFile.ts
+++ b/packages/dofs/src/fs/readFile.ts
@@ -2,8 +2,9 @@ import { createWorkspaceError } from "../errors.js";
 import { canonicalizePath } from "../path.js";
 import type { Database } from "../storage.js";
 import { getBlobBytes } from "./blobCache.js";
+import { findPendingWriteBuffer } from "./pendingWriteBuffer.js";
 import { resolveInode } from "./resolve.js";
-import { getPendingWriteBufferByPath, getWriteBuffer } from "./writeBuffer.js";
+import { getWriteBuffer } from "./writeBuffer.js";
 import { CHUNK_SIZE } from "./writeFile.js";
 
 export interface ReadFileOptions {
@@ -53,7 +54,7 @@ export async function readFile(
   // requested window so the returned stream remains a snapshot while writes
   // continue through the open buffer.
   const { path: canonical } = canonicalizePath(path);
-  const pending = getPendingWriteBufferByPath(db, canonical);
+  const pending = findPendingWriteBuffer(db, canonical);
   if (pending !== undefined) {
     return snapshotResult(pending.buf, pending.size, byteOffset, byteLength, wantString);
   }
@@ -211,7 +212,7 @@ export function readRangeSync(
   // Pending-create files have no inode yet. Serve reads from the
   // path-keyed buffer until release commits the row.
   const { path: canonical } = canonicalizePath(path);
-  const pending = getPendingWriteBufferByPath(db, canonical);
+  const pending = findPendingWriteBuffer(db, canonical);
   if (pending !== undefined) {
     if (length === 0) return new Uint8Array();
     if (offset >= pending.size) return new Uint8Array();

--- a/packages/dofs/src/fs/resolve.ts
+++ b/packages/dofs/src/fs/resolve.ts
@@ -188,6 +188,23 @@ function toResolved(node: NodeRow): ResolvedInode {
   };
 }
 
+function linkTargetParts(target: string, linkParentParts: string[]): string[] {
+  if (target.startsWith("/")) {
+    return canonicalizePath(target).parts;
+  }
+
+  const resolved = [...linkParentParts];
+  for (const part of target.split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      resolved.pop();
+      continue;
+    }
+    resolved.push(part);
+  }
+  return resolved;
+}
+
 function resolveParts(
   db: Database,
   parts: string[],
@@ -226,7 +243,7 @@ function resolveParts(
         throw createWorkspaceError("ELOOP", "too many symlinks resolving path");
       }
       const target = next.link_target ?? "";
-      const resolved = resolveParts(db, canonicalizePath(target).parts, true, follows);
+      const resolved = resolveParts(db, linkTargetParts(target, parts.slice(0, i)), true, follows);
       if (resolved === null) {
         return null;
       }

--- a/packages/dofs/src/fs/resolve.ts
+++ b/packages/dofs/src/fs/resolve.ts
@@ -188,23 +188,6 @@ function toResolved(node: NodeRow): ResolvedInode {
   };
 }
 
-function linkTargetParts(target: string, linkParentParts: string[]): string[] {
-  if (target.startsWith("/")) {
-    return canonicalizePath(target).parts;
-  }
-
-  const resolved = [...linkParentParts];
-  for (const part of target.split("/")) {
-    if (part === "" || part === ".") continue;
-    if (part === "..") {
-      resolved.pop();
-      continue;
-    }
-    resolved.push(part);
-  }
-  return resolved;
-}
-
 function resolveParts(
   db: Database,
   parts: string[],
@@ -216,60 +199,45 @@ function resolveParts(
     return null;
   }
 
-  let current: NodeRow = root;
-  for (let i = 0; i < parts.length; i++) {
-    const isFinal = i === parts.length - 1;
-    if (current.type !== "dir") {
-      return null;
+  const pendingParts = [...parts];
+  const nodeStack: NodeRow[] = [root];
+  while (pendingParts.length > 0) {
+    const name = pendingParts.shift();
+    if (name === undefined) continue;
+    const current = nodeStack[nodeStack.length - 1];
+    if (current.type !== "dir") return null;
+    if (name === "" || name === ".") continue;
+    if (name === "..") {
+      if (nodeStack.length > 1) nodeStack.pop();
+      continue;
     }
+
     const child = db.one<ChildRow>(
       "SELECT child_inode FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
       current.inode,
-      parts[i],
+      name,
     );
-    if (child === undefined) {
-      return null;
-    }
+    if (child === undefined) return null;
     const next = readNode(db, child.child_inode);
-    if (next === null) {
-      return null;
-    }
+    if (next === null) return null;
+
     // Intermediate symlinks always get followed; final-segment symlinks
-    // are only followed when the caller wants. A dangling intermediate
-    // is the same as a missing intermediate (return null).
-    if (next.type === "symlink" && (!isFinal || followFinal)) {
+    // are only followed when the caller wants. Keep target components in
+    // the queue so links before `..` are expanded in filesystem order.
+    if (next.type === "symlink" && (pendingParts.length > 0 || followFinal)) {
       follows += 1;
       if (follows > MAX_SYMLINK_FOLLOWS) {
         throw createWorkspaceError("ELOOP", "too many symlinks resolving path");
       }
       const target = next.link_target ?? "";
-      const resolved = resolveParts(db, linkTargetParts(target, parts.slice(0, i)), true, follows);
-      if (resolved === null) {
-        return null;
-      }
-      // Replace the current dirent-resolved node with the followed
-      // result, then keep walking remaining segments (if any).
-      current = {
-        inode: resolved.inode,
-        type: resolved.type,
-        mode: resolved.mode,
-        mtime: resolved.mtime,
-        size: resolved.size,
-        link_target: resolved.linkTarget ?? null,
-      };
+      if (target.startsWith("/")) nodeStack.splice(1);
+      pendingParts.unshift(...target.split("/"));
       continue;
     }
-    current = next;
+    nodeStack.push(next);
   }
 
-  return {
-    inode: current.inode,
-    type: current.type,
-    mode: current.mode,
-    mtime: current.mtime,
-    size: current.size,
-    linkTarget: current.link_target ?? undefined,
-  };
+  return toResolved(nodeStack[nodeStack.length - 1]);
 }
 
 function readNode(db: Database, inode: number): NodeRow | null {

--- a/packages/dofs/src/fs/stat.ts
+++ b/packages/dofs/src/fs/stat.ts
@@ -1,8 +1,9 @@
 import { createWorkspaceError } from "../errors.js";
 import { canonicalizePath } from "../path.js";
 import type { Database } from "../storage.js";
+import { findPendingWriteBuffer } from "./pendingWriteBuffer.js";
 import { resolveInode } from "./resolve.js";
-import { getPendingWriteBufferByPath, getWriteBuffer } from "./writeBuffer.js";
+import { getWriteBuffer } from "./writeBuffer.js";
 
 export interface WorkspaceStatResult {
   name: string;
@@ -39,7 +40,7 @@ function statShared(db: Database, path: string, followFinal: boolean): Workspace
   // Pending creates never apply to symlinks, so this is safe to run
   // even on the lstat path — a hit here always corresponds to a
   // file mid-open.
-  const pending = getPendingWriteBufferByPath(db, canonical);
+  const pending = findPendingWriteBuffer(db, canonical);
   if (pending !== undefined && pending.pending !== undefined) {
     return {
       name,

--- a/packages/dofs/src/fs/symlink.test.ts
+++ b/packages/dofs/src/fs/symlink.test.ts
@@ -196,6 +196,20 @@ describe("resolveInode + symlinks", () => {
     });
   });
 
+  it.each(["file/", "file//", "file/../target"])(
+    "does not traverse past a file in the target %s",
+    async (target) => {
+      await withDB(async (db) => {
+        await writeFile(db, "/file", "file", {}, () => 0);
+        await writeFile(db, "/target", "target", {}, () => 0);
+        symlink(db, target, "/link", () => 0);
+
+        expect(resolveInode(db, "/link")).toBeNull();
+        await expect(readFile(db, "/link", "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+      });
+    },
+  );
+
   it("throws ELOOP on a cycle", async () => {
     await withDB((db) => {
       symlink(db, "/b", "/a", () => 0);

--- a/packages/dofs/src/fs/symlink.test.ts
+++ b/packages/dofs/src/fs/symlink.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { mkdir } from "./mkdir.js";
 import { invalidateReadOnlyMountCache } from "./mount-guard.js";
+import { readFile } from "./readFile.js";
 import { readlink } from "./readlink.js";
 import { resolveInode } from "./resolve.js";
+import { stat } from "./stat.js";
 import { symlink } from "./symlink.js";
 import { withDB } from "./with-db.js";
 import { writeFile } from "./writeFile.js";
@@ -137,6 +139,60 @@ describe("resolveInode + symlinks", () => {
       symlink(db, "/no/such/target", "/dangling", () => 0);
       const node = resolveInode(db, "/dangling", { followSymlinks: false });
       expect(node?.type).toBe("symlink");
+    });
+  });
+
+  it("resolves a bare relative target from the symlink parent", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/dir", {}, () => 0);
+      await writeFile(db, "/dir/target", "hello", {}, () => 0);
+      symlink(db, "target", "/dir/link", () => 0);
+
+      expect(resolveInode(db, "/dir/link")?.inode).toBe(resolveInode(db, "/dir/target")?.inode);
+      await expect(readFile(db, "/dir/link", "utf8")).resolves.toBe("hello");
+    });
+  });
+
+  it("resolves dot and parent segments in relative symlink targets", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/dir/sub", { recursive: true }, () => 0);
+      await writeFile(db, "/dir/target", "hello", {}, () => 0);
+      symlink(db, "./target", "/dir/dot-link", () => 0);
+      symlink(db, "../target", "/dir/sub/parent-link", () => 0);
+
+      expect(resolveInode(db, "/dir/dot-link")?.inode).toBe(resolveInode(db, "/dir/target")?.inode);
+      expect(resolveInode(db, "/dir/sub/parent-link")?.inode).toBe(
+        resolveInode(db, "/dir/target")?.inode,
+      );
+    });
+  });
+
+  it("clamps leading parent segments in relative symlink targets at the root", async () => {
+    await withDB(async (db) => {
+      await writeFile(db, "/target", "hello", {}, () => 0);
+      symlink(db, "../../target", "/link", () => 0);
+
+      expect(resolveInode(db, "/link")?.inode).toBe(resolveInode(db, "/target")?.inode);
+    });
+  });
+
+  it("resolves remaining path segments after a relative symlink", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/dir/real", { recursive: true }, () => 0);
+      await writeFile(db, "/dir/real/file.txt", "hello", {}, () => 0);
+      symlink(db, "real", "/dir/link", () => 0);
+
+      expect(resolveInode(db, "/dir/link/file.txt")?.inode).toBe(
+        resolveInode(db, "/dir/real/file.txt")?.inode,
+      );
+    });
+  });
+
+  it("reports ENOENT for a dangling relative symlink target", async () => {
+    await withDB((db) => {
+      symlink(db, "missing", "/dangling", () => 0);
+
+      expect(() => stat(db, "/dangling")).toThrowError(expect.objectContaining({ code: "ENOENT" }));
     });
   });
 

--- a/packages/dofs/src/fs/writeBuffer.test.ts
+++ b/packages/dofs/src/fs/writeBuffer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { Database } from "../storage.js";
 import { mkdir } from "./mkdir.js";
+import { findPendingWriteBuffer } from "./pendingWriteBuffer.js";
 import { readRangeSync } from "./readFile.js";
 import { resolveInode } from "./resolve.js";
 import { stat } from "./stat.js";
@@ -150,6 +151,20 @@ describe("buffered write lifecycle", () => {
 });
 
 describe("deferred-create lifecycle", () => {
+  it("skips parent resolution when no pending buffers exist", async () => {
+    await withDB((db) => {
+      const originalAll = db.all.bind(db);
+      let queries = 0;
+      db.all = ((query: string, ...bindings: unknown[]) => {
+        queries += 1;
+        return originalAll(query, ...bindings);
+      }) as typeof db.all;
+
+      expect(findPendingWriteBuffer(db, "/missing/file.txt")).toBeUndefined();
+      expect(queries).toBe(0);
+    });
+  });
+
   it("holds the file in memory until release commits one transaction", async () => {
     await withDB(async (db) => {
       openWriteBufferForCreateSync(db, "/pending.txt", { mode: 0o600 }, () => 1000);

--- a/packages/dofs/src/fs/writeBuffer.test.ts
+++ b/packages/dofs/src/fs/writeBuffer.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import type { Database } from "../storage.js";
+import { mkdir } from "./mkdir.js";
 import { readRangeSync } from "./readFile.js";
 import { resolveInode } from "./resolve.js";
 import { stat } from "./stat.js";
+import { symlink } from "./symlink.js";
 import { withDB } from "./with-db.js";
 import {
   CHUNK_SIZE,
@@ -172,6 +174,20 @@ describe("deferred-create lifecycle", () => {
       expect(stat(db, "/pending.txt").size).toBe(5);
       expect(blobCount(db)).toBe(1);
       expect(orphanBlobCount(db)).toBe(0);
+    });
+  });
+
+  it("invalidates the real path after releasing through a symlinked parent", async () => {
+    await withDB((db) => {
+      mkdir(db, "/real", {}, () => 1000);
+      symlink(db, "/real", "/linkdir", () => 1000);
+      expect(resolveInode(db, "/real/pending.txt")).toBeNull();
+
+      openWriteBufferForCreateSync(db, "/linkdir/pending.txt", {}, () => 1000);
+      writeRangeSync(db, "/linkdir/pending.txt", bytesOf("hello"), 0, {}, () => 1001);
+      releaseWriteBufferSync(db, "/linkdir/pending.txt", () => 1002);
+
+      expect(resolveInode(db, "/real/pending.txt")?.type).toBe("file");
     });
   });
 

--- a/packages/dofs/src/fs/writeBuffer.test.ts
+++ b/packages/dofs/src/fs/writeBuffer.test.ts
@@ -194,6 +194,27 @@ describe("deferred-create lifecycle", () => {
     });
   });
 
+  it("keeps pending buffer operations free of path lookup queries", async () => {
+    await withDB((db) => {
+      mkdir(db, "/deep/real", { recursive: true }, () => 1000);
+      symlink(db, "/deep/real", "/linkdir", () => 1000);
+      openWriteBufferForCreateSync(db, "/linkdir/pending.txt", {}, () => 1000);
+
+      const originalOne = db.one.bind(db);
+      let lookups = 0;
+      db.one = ((query: string, ...bindings: unknown[]) => {
+        lookups += 1;
+        return originalOne(query, ...bindings);
+      }) as typeof db.one;
+
+      writeRangeSync(db, "/linkdir/pending.txt", bytesOf("hello"), 0, {}, () => 1001);
+      truncateFileSync(db, "/linkdir/pending.txt", 3, () => 1002);
+      openWriteBufferSync(db, "/linkdir/pending.txt");
+
+      expect(lookups).toBe(0);
+    });
+  });
+
   it("rejects a second openWriteBufferForCreateSync against the same path", async () => {
     await withDB(async (db) => {
       openWriteBufferForCreateSync(db, "/dupe.txt", {}, () => 1000);

--- a/packages/dofs/src/fs/writeBuffer.test.ts
+++ b/packages/dofs/src/fs/writeBuffer.test.ts
@@ -194,6 +194,22 @@ describe("deferred-create lifecycle", () => {
     });
   });
 
+  it("exposes a pending create through every alias of its parent", async () => {
+    await withDB((db) => {
+      mkdir(db, "/real", {}, () => 1000);
+      symlink(db, "/real", "/a", () => 1000);
+      symlink(db, "/real", "/b", () => 1000);
+      openWriteBufferForCreateSync(db, "/a/pending.txt", {}, () => 1000);
+
+      expect(stat(db, "/b/pending.txt").size).toBe(0);
+      writeRangeSync(db, "/b/pending.txt", bytesOf("hello"), 0, {}, () => 1001);
+      expect(new TextDecoder().decode(readRangeSync(db, "/b/pending.txt", 0, 5))).toBe("hello");
+      releaseWriteBufferSync(db, "/b/pending.txt", () => 1002);
+
+      expect(resolveInode(db, "/real/pending.txt")?.type).toBe("file");
+    });
+  });
+
   it("keeps pending buffer operations free of path lookup queries", async () => {
     await withDB((db) => {
       mkdir(db, "/deep/real", { recursive: true }, () => 1000);

--- a/packages/dofs/src/fs/writeBuffer.test.ts
+++ b/packages/dofs/src/fs/writeBuffer.test.ts
@@ -177,15 +177,18 @@ describe("deferred-create lifecycle", () => {
     });
   });
 
-  it("invalidates the real path after releasing through a symlinked parent", async () => {
+  it("exposes a symlinked pending create through its real path", async () => {
     await withDB((db) => {
       mkdir(db, "/real", {}, () => 1000);
       symlink(db, "/real", "/linkdir", () => 1000);
       expect(resolveInode(db, "/real/pending.txt")).toBeNull();
 
       openWriteBufferForCreateSync(db, "/linkdir/pending.txt", {}, () => 1000);
-      writeRangeSync(db, "/linkdir/pending.txt", bytesOf("hello"), 0, {}, () => 1001);
-      releaseWriteBufferSync(db, "/linkdir/pending.txt", () => 1002);
+      expect(stat(db, "/real/pending.txt").size).toBe(0);
+      writeRangeSync(db, "/real/pending.txt", bytesOf("hello"), 0, {}, () => 1001);
+      expect(stat(db, "/real/pending.txt").size).toBe(5);
+      expect(new TextDecoder().decode(readRangeSync(db, "/real/pending.txt", 0, 5))).toBe("hello");
+      releaseWriteBufferSync(db, "/real/pending.txt", () => 1002);
 
       expect(resolveInode(db, "/real/pending.txt")?.type).toBe("file");
     });

--- a/packages/dofs/src/fs/writeBuffer.ts
+++ b/packages/dofs/src/fs/writeBuffer.ts
@@ -38,6 +38,7 @@ export interface WriteBufferEntry {
     parentInode: number;
     leafName: string;
     canonicalPath: string;
+    resolvedPath: string;
     pendingInode: number;
     mtime: number;
   };
@@ -78,7 +79,7 @@ export function listPendingByParent(db: Database, parentInode: number): WriteBuf
   const cache = caches.get(db);
   if (cache === undefined) return [];
   const out: WriteBufferEntry[] = [];
-  for (const entry of cache.byPendingPath.values()) {
+  for (const entry of cache.byInode.values()) {
     if (entry.pending?.parentInode === parentInode) out.push(entry);
   }
   return out;
@@ -89,6 +90,7 @@ export function setWriteBuffer(db: Database, inode: number, entry: WriteBufferEn
   cache.byInode.set(inode, entry);
   if (entry.pending !== undefined) {
     cache.byPendingPath.set(entry.pending.canonicalPath, entry);
+    cache.byPendingPath.set(entry.pending.resolvedPath, entry);
   }
 }
 
@@ -98,6 +100,7 @@ export function deleteWriteBuffer(db: Database, inode: number): void {
   const entry = cache.byInode.get(inode);
   if (entry?.pending !== undefined) {
     cache.byPendingPath.delete(entry.pending.canonicalPath);
+    cache.byPendingPath.delete(entry.pending.resolvedPath);
   }
   cache.byInode.delete(inode);
 }
@@ -122,6 +125,7 @@ export function promotePendingToInode(db: Database, pendingInode: number, realIn
   if (entry === undefined) return;
   if (entry.pending !== undefined) {
     cache.byPendingPath.delete(entry.pending.canonicalPath);
+    cache.byPendingPath.delete(entry.pending.resolvedPath);
     entry.pending = undefined;
   }
   cache.byInode.delete(pendingInode);

--- a/packages/dofs/src/fs/writeBuffer.ts
+++ b/packages/dofs/src/fs/writeBuffer.ts
@@ -48,6 +48,7 @@ export interface WriteBufferEntry {
 interface DatabaseCache {
   byInode: Map<number, WriteBufferEntry>;
   byPendingPath: Map<string, WriteBufferEntry>;
+  byPendingParent: Map<string, WriteBufferEntry>;
   nextPendingInode: number;
 }
 
@@ -56,7 +57,12 @@ const caches = new WeakMap<Database, DatabaseCache>();
 function cacheFor(db: Database): DatabaseCache {
   let cache = caches.get(db);
   if (cache === undefined) {
-    cache = { byInode: new Map(), byPendingPath: new Map(), nextPendingInode: -1 };
+    cache = {
+      byInode: new Map(),
+      byPendingPath: new Map(),
+      byPendingParent: new Map(),
+      nextPendingInode: -1,
+    };
     caches.set(db, cache);
   }
   return cache;
@@ -71,6 +77,18 @@ export function getPendingWriteBufferByPath(
   canonicalPath: string,
 ): WriteBufferEntry | undefined {
   return caches.get(db)?.byPendingPath.get(canonicalPath);
+}
+
+function pendingParentKey(parentInode: number, leafName: string): string {
+  return `${parentInode}:${leafName}`;
+}
+
+export function getPendingWriteBufferByParent(
+  db: Database,
+  parentInode: number,
+  leafName: string,
+): WriteBufferEntry | undefined {
+  return caches.get(db)?.byPendingParent.get(pendingParentKey(parentInode, leafName));
 }
 
 // List pending-create buffers whose parent dirent matches `parentInode`.
@@ -92,6 +110,10 @@ export function setWriteBuffer(db: Database, inode: number, entry: WriteBufferEn
   if (entry.pending !== undefined) {
     cache.byPendingPath.set(entry.pending.canonicalPath, entry);
     cache.byPendingPath.set(entry.pending.resolvedPath, entry);
+    cache.byPendingParent.set(
+      pendingParentKey(entry.pending.parentInode, entry.pending.leafName),
+      entry,
+    );
   }
 }
 
@@ -102,6 +124,9 @@ export function deleteWriteBuffer(db: Database, inode: number): void {
   if (entry?.pending !== undefined) {
     cache.byPendingPath.delete(entry.pending.canonicalPath);
     cache.byPendingPath.delete(entry.pending.resolvedPath);
+    cache.byPendingParent.delete(
+      pendingParentKey(entry.pending.parentInode, entry.pending.leafName),
+    );
   }
   cache.byInode.delete(inode);
 }
@@ -127,6 +152,9 @@ export function promotePendingToInode(db: Database, pendingInode: number, realIn
   if (entry.pending !== undefined) {
     cache.byPendingPath.delete(entry.pending.canonicalPath);
     cache.byPendingPath.delete(entry.pending.resolvedPath);
+    cache.byPendingParent.delete(
+      pendingParentKey(entry.pending.parentInode, entry.pending.leafName),
+    );
     entry.pending = undefined;
   }
   cache.byInode.delete(pendingInode);

--- a/packages/dofs/src/fs/writeBuffer.ts
+++ b/packages/dofs/src/fs/writeBuffer.ts
@@ -76,13 +76,13 @@ export function getPendingWriteBufferByPath(
 // Used by readdir so freshly-created-but-not-yet-released files show
 // up in directory listings between open and release.
 export function listPendingByParent(db: Database, parentInode: number): WriteBufferEntry[] {
+  return listPendingWriteBuffers(db).filter((entry) => entry.pending?.parentInode === parentInode);
+}
+
+export function listPendingWriteBuffers(db: Database): WriteBufferEntry[] {
   const cache = caches.get(db);
   if (cache === undefined) return [];
-  const out: WriteBufferEntry[] = [];
-  for (const entry of cache.byInode.values()) {
-    if (entry.pending?.parentInode === parentInode) out.push(entry);
-  }
-  return out;
+  return [...cache.byInode.values()].filter((entry) => entry.pending !== undefined);
 }
 
 export function setWriteBuffer(db: Database, inode: number, entry: WriteBufferEntry): void {

--- a/packages/dofs/src/fs/writeBuffer.ts
+++ b/packages/dofs/src/fs/writeBuffer.ts
@@ -39,6 +39,7 @@ export interface WriteBufferEntry {
     leafName: string;
     canonicalPath: string;
     resolvedPath: string;
+    ancestorInodes: number[];
     pendingInode: number;
     mtime: number;
   };

--- a/packages/dofs/src/fs/writeBuffer.ts
+++ b/packages/dofs/src/fs/writeBuffer.ts
@@ -96,6 +96,10 @@ export function getPendingWriteBufferByParent(
   return caches.get(db)?.byPendingParent.get(pendingParentKey(parentInode, leafName));
 }
 
+export function hasPendingWriteBuffers(db: Database): boolean {
+  return (caches.get(db)?.byPendingParent.size ?? 0) > 0;
+}
+
 // List pending-create buffers whose parent dirent matches `parentInode`.
 // Used by readdir so freshly-created-but-not-yet-released files show
 // up in directory listings between open and release.

--- a/packages/dofs/src/fs/writeBuffer.ts
+++ b/packages/dofs/src/fs/writeBuffer.ts
@@ -29,6 +29,11 @@ export interface WriteBufferEntry {
   // Mode the caller wants persisted on release. Defaults to the
   // inode's existing mode at open time when the caller has none.
   mode: number;
+  // Lexical and effective paths used by the most recent successful
+  // mutation. Dirty release validates these paths rather than whichever
+  // hardlink alias happens to close last.
+  dirtyPath?: string;
+  dirtyTargetPath?: string;
   // Pending-create state. When set, no inode row exists yet; release
   // will INSERT the node + dirent + chunks in one transaction. The
   // synthetic inode id used to key this entry in the cache is stored

--- a/packages/dofs/src/fs/writeFile.test.ts
+++ b/packages/dofs/src/fs/writeFile.test.ts
@@ -353,6 +353,35 @@ describe("writeFile", () => {
     });
   });
 
+  it("resolves a relative final symlink from its real parent", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/real/nested", { recursive: true }, () => 0);
+      symlink(db, "/real/nested", "/alias", () => 0);
+      symlink(db, "../target", "/real/nested/link", () => 0);
+
+      await writeFile(db, "/alias/link", "hello", {}, () => 0);
+
+      expect(new TextDecoder().decode(readBack(db, "/real/target"))).toBe("hello");
+      expect(new TextDecoder().decode(readBack(db, "/alias/link"))).toBe("hello");
+      expect(resolveInode(db, "/target")).toBeNull();
+    });
+  });
+
+  it("expands a symlink before applying a later parent segment in its target", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/base/dir", { recursive: true }, () => 0);
+      mkdir(db, "/other/deep", { recursive: true }, () => 0);
+      symlink(db, "/other/deep", "/base/dir/alias", () => 0);
+      symlink(db, "alias/../target", "/base/dir/link", () => 0);
+
+      await writeFile(db, "/base/dir/link", "hello", {}, () => 0);
+
+      expect(new TextDecoder().decode(readBack(db, "/other/target"))).toBe("hello");
+      expect(new TextDecoder().decode(readBack(db, "/base/dir/link"))).toBe("hello");
+      expect(resolveInode(db, "/base/dir/target")).toBeNull();
+    });
+  });
+
   it("rejects ENOTDIR when an intermediate symlink resolves to a file", async () => {
     await withDB(async (db) => {
       await writeFile(db, "/target", "file", {}, () => 0);
@@ -374,6 +403,26 @@ describe("writeFile", () => {
       await expect(writeFile(db, "/a/child.txt", "hello", {}, () => 0)).rejects.toMatchObject({
         code: "ELOOP",
       });
+    });
+  });
+
+  it("counts intermediate and final symlinks against one follow limit", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/real", {}, () => 0);
+      for (let index = 29; index >= 0; index--) {
+        const target = index === 29 ? "/real" : `/dir-${index + 1}`;
+        symlink(db, target, `/dir-${index}`, () => 0);
+      }
+      for (let index = 19; index >= 0; index--) {
+        const target = index === 19 ? "/missing" : `/file-${index + 1}`;
+        symlink(db, target, `/file-${index}`, () => 0);
+      }
+      symlink(db, "/file-0", "/real/link", () => 0);
+
+      await expect(writeFile(db, "/dir-0/link", "hello", {}, () => 0)).rejects.toMatchObject({
+        code: "ELOOP",
+      });
+      expect(resolveInode(db, "/missing")).toBeNull();
     });
   });
 
@@ -413,6 +462,18 @@ describe("writeFile", () => {
       await writeFile(db, "/dir/link", "new", {}, () => 0);
 
       expect(new TextDecoder().decode(readBack(db, "/dir/created"))).toBe("new");
+    });
+  });
+
+  it("creates the missing target at the end of a dangling symlink chain", async () => {
+    await withDB(async (db) => {
+      symlink(db, "/mid", "/link", () => 0);
+      symlink(db, "/missing", "/mid", () => 0);
+
+      await writeFile(db, "/link", "new", {}, () => 0);
+
+      expect(new TextDecoder().decode(readBack(db, "/missing"))).toBe("new");
+      expect(resolveInode(db, "/mid", { followSymlinks: false })?.type).toBe("symlink");
     });
   });
 

--- a/packages/dofs/src/fs/writeFile.test.ts
+++ b/packages/dofs/src/fs/writeFile.test.ts
@@ -275,6 +275,16 @@ describe("writeFile", () => {
     });
   });
 
+  it("rejects ENOTDIR when a deep parent path segment is a file", async () => {
+    await withDB(async (db) => {
+      await writeFile(db, "/target", "file", {}, () => 0);
+
+      await expect(
+        writeFile(db, "/target/sub/child.txt", "hello", {}, () => 0),
+      ).rejects.toMatchObject({ code: "ENOTDIR" });
+    });
+  });
+
   it("rejects EISDIR when the path resolves to a directory", async () => {
     await withDB(async (db) => {
       mkdir(db, "/d", {}, () => 0);

--- a/packages/dofs/src/fs/writeFile.test.ts
+++ b/packages/dofs/src/fs/writeFile.test.ts
@@ -342,6 +342,18 @@ describe("writeFile", () => {
     });
   });
 
+  it("invalidates a cached miss at the resolved path after writing through a symlinked parent", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/real", {}, () => 0);
+      symlink(db, "/real", "/linkdir", () => 0);
+      expect(resolveInode(db, "/real/file.txt")).toBeNull();
+
+      await writeFile(db, "/linkdir/file.txt", "hello", {}, () => 0);
+
+      expect(new TextDecoder().decode(readBack(db, "/real/file.txt"))).toBe("hello");
+    });
+  });
+
   it("writes through an intermediate relative symlink to a directory", async () => {
     await withDB(async (db) => {
       mkdir(db, "/base/real", { recursive: true }, () => 0);

--- a/packages/dofs/src/fs/writeFile.test.ts
+++ b/packages/dofs/src/fs/writeFile.test.ts
@@ -477,6 +477,28 @@ describe("writeFile", () => {
     });
   });
 
+  it("clamps final symlink targets that climb above the root", async () => {
+    await withDB(async (db) => {
+      symlink(db, "../../created", "/link", () => 0);
+
+      await writeFile(db, "/link", "new", {}, () => 0);
+
+      expect(new TextDecoder().decode(readBack(db, "/created"))).toBe("new");
+      expect(new TextDecoder().decode(readBack(db, "/link"))).toBe("new");
+    });
+  });
+
+  it("clamps intermediate symlink targets that climb above the root", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/real", {}, () => 0);
+      symlink(db, "../../real", "/linkdir", () => 0);
+
+      await writeFile(db, "/linkdir/file.txt", "new", {}, () => 0);
+
+      expect(new TextDecoder().decode(readBack(db, "/real/file.txt"))).toBe("new");
+    });
+  });
+
   it("creates the missing target at the end of a dangling symlink chain", async () => {
     await withDB(async (db) => {
       symlink(db, "/mid", "/link", () => 0);

--- a/packages/dofs/src/fs/writeFile.test.ts
+++ b/packages/dofs/src/fs/writeFile.test.ts
@@ -348,7 +348,9 @@ describe("writeFile", () => {
       await writeFile(db, "/target", "file", {}, () => 0);
       symlink(db, "/target", "/linkfile", () => 0);
 
-      await expect(writeFile(db, "/linkfile/child.txt", "hello", {}, () => 0)).rejects.toMatchObject({
+      await expect(
+        writeFile(db, "/linkfile/child.txt", "hello", {}, () => 0),
+      ).rejects.toMatchObject({
         code: "ENOTDIR",
       });
     });
@@ -362,6 +364,82 @@ describe("writeFile", () => {
       await expect(writeFile(db, "/a/child.txt", "hello", {}, () => 0)).rejects.toMatchObject({
         code: "ELOOP",
       });
+    });
+  });
+
+  it("writes through a final symlink to its target", async () => {
+    await withDB(async (db) => {
+      await writeFile(db, "/target", "old", {}, () => 0);
+      symlink(db, "/target", "/link", () => 0);
+
+      await writeFile(db, "/link", "new", {}, () => 0);
+
+      expect(new TextDecoder().decode(readBack(db, "/target"))).toBe("new");
+      expect(new TextDecoder().decode(readBack(db, "/link"))).toBe("new");
+      expect(
+        db.scalar<number>(
+          "SELECT COUNT(*) FROM vfs_chunks c JOIN vfs_nodes n ON n.inode = c.inode WHERE n.type = 'symlink'",
+        ),
+      ).toBe(0);
+      expect(db.scalar<number>("SELECT size FROM vfs_nodes WHERE type = 'symlink'")).toBe(0);
+    });
+  });
+
+  it("creates the target when writing through a dangling final symlink", async () => {
+    await withDB(async (db) => {
+      symlink(db, "/created", "/link", () => 0);
+
+      await writeFile(db, "/link", "new", {}, () => 0);
+
+      expect(new TextDecoder().decode(readBack(db, "/created"))).toBe("new");
+    });
+  });
+
+  it("creates a relative target from the symlink parent when writing through a dangling final symlink", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/dir", {}, () => 0);
+      symlink(db, "created", "/dir/link", () => 0);
+
+      await writeFile(db, "/dir/link", "new", {}, () => 0);
+
+      expect(new TextDecoder().decode(readBack(db, "/dir/created"))).toBe("new");
+    });
+  });
+
+  it("keeps exclusive writes on a final symlink from following the link", async () => {
+    await withDB(async (db) => {
+      await writeFile(db, "/target", "old", {}, () => 0);
+      symlink(db, "/target", "/link", () => 0);
+
+      await expect(
+        writeFile(db, "/link", "new", { exclusive: true }, () => 0),
+      ).rejects.toMatchObject({
+        code: "EEXIST",
+      });
+      expect(new TextDecoder().decode(readBack(db, "/target"))).toBe("old");
+    });
+  });
+
+  it("range writes follow a final symlink", async () => {
+    await withDB(async (db) => {
+      await writeFile(db, "/target", "abc", {}, () => 0);
+      symlink(db, "/target", "/link", () => 0);
+
+      writeFileRangesSync(
+        db,
+        "/link",
+        new TextEncoder().encode("axc"),
+        [{ start: 1, end: 2 }],
+        {},
+        () => 0,
+      );
+
+      expect(new TextDecoder().decode(readBack(db, "/target"))).toBe("axc");
+      expect(
+        db.scalar<number>(
+          "SELECT COUNT(*) FROM vfs_chunks c JOIN vfs_nodes n ON n.inode = c.inode WHERE n.type = 'symlink'",
+        ),
+      ).toBe(0);
     });
   });
 

--- a/packages/dofs/src/fs/writeFile.test.ts
+++ b/packages/dofs/src/fs/writeFile.test.ts
@@ -4,6 +4,7 @@ import { ROOT_INODE } from "../schema/index.js";
 import type { Database } from "../storage.js";
 import { mkdir } from "./mkdir.js";
 import { resolveInode } from "./resolve.js";
+import { symlink } from "./symlink.js";
 import { withDB } from "./with-db.js";
 import { CHUNK_SIZE, writeFile, writeFileRangesSync, writeFileSync } from "./writeFile.js";
 
@@ -317,6 +318,50 @@ describe("writeFile", () => {
       mkdir(db, "/a/b", { recursive: true }, () => 0);
       await writeFile(db, "/a/b/c.txt", "nested", {}, () => 0);
       expect(new TextDecoder().decode(readBack(db, "/a/b/c.txt"))).toBe("nested");
+    });
+  });
+
+  it("writes through an intermediate symlink to a directory", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/real", {}, () => 0);
+      symlink(db, "/real", "/linkdir", () => 0);
+
+      await writeFile(db, "/linkdir/file.txt", "hello", {}, () => 0);
+
+      expect(new TextDecoder().decode(readBack(db, "/real/file.txt"))).toBe("hello");
+    });
+  });
+
+  it("writes through an intermediate relative symlink to a directory", async () => {
+    await withDB(async (db) => {
+      mkdir(db, "/base/real", { recursive: true }, () => 0);
+      symlink(db, "real", "/base/linkdir", () => 0);
+
+      await writeFile(db, "/base/linkdir/file.txt", "hello", {}, () => 0);
+
+      expect(new TextDecoder().decode(readBack(db, "/base/real/file.txt"))).toBe("hello");
+    });
+  });
+
+  it("rejects ENOTDIR when an intermediate symlink resolves to a file", async () => {
+    await withDB(async (db) => {
+      await writeFile(db, "/target", "file", {}, () => 0);
+      symlink(db, "/target", "/linkfile", () => 0);
+
+      await expect(writeFile(db, "/linkfile/child.txt", "hello", {}, () => 0)).rejects.toMatchObject({
+        code: "ENOTDIR",
+      });
+    });
+  });
+
+  it("rejects ELOOP when an intermediate symlink is cyclic", async () => {
+    await withDB(async (db) => {
+      symlink(db, "/b", "/a", () => 0);
+      symlink(db, "/a", "/b", () => 0);
+
+      await expect(writeFile(db, "/a/child.txt", "hello", {}, () => 0)).rejects.toMatchObject({
+        code: "ELOOP",
+      });
     });
   });
 

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -18,6 +18,7 @@ import {
   getPendingWriteBufferByPath,
   getWriteBuffer,
   listPendingByParent,
+  listPendingWriteBuffers,
   promotePendingToInode,
   setWriteBuffer,
   type WriteBufferEntry,
@@ -943,7 +944,8 @@ export function flushPendingByPath(db: Database, path: string, now: () => number
 
 /** @internal Commits pending files below a directory before its dirent moves or disappears. */
 export function flushPendingUnderDirectory(db: Database, path: string, now: () => number): void {
-  const directory = resolveInode(db, path, { followSymlinks: false });
+  const { path: canonical } = canonicalizePath(path);
+  const directory = resolveInode(db, canonical, { followSymlinks: false });
   if (directory?.type !== "dir") return;
 
   const parents = db.all<{ inode: number }>(
@@ -959,7 +961,11 @@ export function flushPendingUnderDirectory(db: Database, path: string, now: () =
     SELECT inode FROM descendant_dirs`,
     directory.inode,
   );
-  const entries = parents.flatMap(({ inode }) => listPendingByParent(db, inode));
+  const entries = new Set(parents.flatMap(({ inode }) => listPendingByParent(db, inode)));
+  const lexicalPrefix = canonical === "/" ? "/" : `${canonical}/`;
+  for (const entry of listPendingWriteBuffers(db)) {
+    if (entry.pending?.canonicalPath.startsWith(lexicalPrefix)) entries.add(entry);
+  }
   for (const entry of entries) {
     if (entry.pending !== undefined) commitPendingBuffer(db, entry, now);
   }

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -193,11 +193,8 @@ function childPath(db: Database, parentInode: number, leafName: string, path: st
   return parentPath === "/" ? `/${leafName}` : `${parentPath}/${leafName}`;
 }
 
-function pendingTargetPath(db: Database, entry: WriteBufferEntry, fallback: string): string {
-  const pending = entry.pending;
-  return pending === undefined
-    ? fallback
-    : childPath(db, pending.parentInode, pending.leafName, pending.canonicalPath);
+function pendingTargetPath(entry: WriteBufferEntry, fallback: string): string {
+  return entry.pending?.resolvedPath ?? fallback;
 }
 
 function symlinkTargetParts(target: string, linkParentParts: string[]): string[] {
@@ -991,7 +988,7 @@ export function writeRangeSync(
   // straight into the path-keyed buffer.
   const pending = getPendingWriteBufferByPath(db, canonical);
   if (pending !== undefined) {
-    assertNotReadOnly(db, pendingTargetPath(db, pending, canonical));
+    assertNotReadOnly(db, pendingTargetPath(pending, canonical));
     const writeEnd = offset + bytes.byteLength;
     ensureBufferCapacity(pending, writeEnd);
     if (offset > pending.size) {
@@ -1069,7 +1066,7 @@ export function truncateFileSync(
   // Pending-create files truncate in-place on the path-keyed buffer.
   const pending = getPendingWriteBufferByPath(db, canonical);
   if (pending !== undefined) {
-    assertNotReadOnly(db, pendingTargetPath(db, pending, canonical));
+    assertNotReadOnly(db, pendingTargetPath(pending, canonical));
     if (size > pending.size) {
       ensureBufferCapacity(pending, size);
       pending.buf.fill(0, pending.size, size);

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -17,7 +17,6 @@ import {
   ensureCapacity as ensureBufferCapacity,
   getPendingWriteBufferByPath,
   getWriteBuffer,
-  listPendingByParent,
   listPendingWriteBuffers,
   promotePendingToInode,
   setWriteBuffer,
@@ -944,29 +943,14 @@ export function flushPendingByPath(db: Database, path: string, now: () => number
 
 /** @internal Commits pending files below a directory before its dirent moves or disappears. */
 export function flushPendingUnderDirectory(db: Database, path: string, now: () => number): void {
-  const { path: canonical } = canonicalizePath(path);
-  const directory = resolveInode(db, canonical, { followSymlinks: false });
+  const directory = resolveInode(db, path, { followSymlinks: false });
   if (directory?.type !== "dir") return;
 
-  const parents = db.all<{ inode: number }>(
-    `WITH RECURSIVE descendant_dirs(inode) AS (
-      SELECT ?
-      UNION ALL
-      SELECT dirent.child_inode
-      FROM vfs_dirents AS dirent
-      JOIN descendant_dirs AS parent ON dirent.parent_inode = parent.inode
-      JOIN vfs_nodes AS node ON node.inode = dirent.child_inode
-      WHERE node.type = 'dir'
-    )
-    SELECT inode FROM descendant_dirs`,
-    directory.inode,
-  );
-  const entries = new Set(parents.flatMap(({ inode }) => listPendingByParent(db, inode)));
-  const lexicalPrefix = canonical === "/" ? "/" : `${canonical}/`;
+  // A pending file can be lexically beneath this directory while its
+  // resolved parent is elsewhere through a symlink, and either path
+  // may itself have multiple aliases. Structural changes are rare, so
+  // commit every pending create rather than leave an alias stale.
   for (const entry of listPendingWriteBuffers(db)) {
-    if (entry.pending?.canonicalPath.startsWith(lexicalPrefix)) entries.add(entry);
-  }
-  for (const entry of entries) {
     if (entry.pending !== undefined) commitPendingBuffer(db, entry, now);
   }
 }

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -93,6 +93,7 @@ function resolveParent(
       throw createWorkspaceError("ENOENT", `dangling dirent: ${canonical}`, canonical);
     }
     if (node.type === "symlink") {
+      ancestorInodes.add(node.inode);
       countSymlinkFollow(follows, canonical);
       const target = node.link_target ?? "";
       const targetParts = symlinkTargetParts(target, realParts);
@@ -948,13 +949,13 @@ export function flushPendingByPath(db: Database, path: string, now: () => number
   return true;
 }
 
-/** @internal Commits pending files below a directory before its dirent moves or disappears. */
-export function flushPendingUnderDirectory(db: Database, path: string, now: () => number): void {
-  const directory = resolveInode(db, path, { followSymlinks: false });
-  if (directory?.type !== "dir") return;
+/** @internal Commits pending files reached through a node before its dirent changes. */
+export function flushPendingUnderNode(db: Database, path: string, now: () => number): void {
+  const node = resolveInode(db, path, { followSymlinks: false });
+  if (node === null) return;
 
   for (const entry of listPendingWriteBuffers(db)) {
-    if (entry.pending?.ancestorInodes.includes(directory.inode)) {
+    if (entry.pending?.ancestorInodes.includes(node.inode)) {
       commitPendingBuffer(db, entry, now);
     }
   }

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -8,6 +8,7 @@ import { stageBlob } from "../sync/blobs.js";
 import { buildManifest } from "../sync/manifests.js";
 import { getBlobBytes } from "./blobCache.js";
 import { assertNotReadOnly } from "./mount-guard.js";
+import { resolveInode } from "./resolve.js";
 import { invalidateResolveExact } from "./resolveCache.js";
 import {
   allocatePendingInode,
@@ -39,36 +40,24 @@ export interface WriteFileRange {
 
 // Resolve directory-only paths (the parent of the target file). The
 // final segment is handled by the caller. Returns the parent inode or
-// throws ENOENT/ENOTDIR.
+// throws ENOENT/ENOTDIR. Intermediate symlinks are followed by the
+// normal resolver so writes match read/path-resolution semantics.
 function resolveParent(db: Database, parts: string[], canonical: string): number {
-  let parentInode = ROOT_INODE;
-  for (let i = 0; i < parts.length - 1; i++) {
-    const name = parts[i];
-    const child = db.one<{ child_inode: number }>(
-      "SELECT child_inode FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
-      parentInode,
-      name,
-    );
-    if (child === undefined) {
-      throw createWorkspaceError("ENOENT", `parent directory missing: ${canonical}`, canonical);
-    }
-    const next = db.one<{ inode: number; type: "file" | "dir" }>(
-      "SELECT inode, type FROM vfs_nodes WHERE inode = ?",
-      child.child_inode,
-    );
-    if (next === undefined) {
-      throw createWorkspaceError("ENOENT", `dangling dirent: ${canonical}`, canonical);
-    }
-    if (next.type !== "dir") {
-      throw createWorkspaceError(
-        "ENOTDIR",
-        `parent path segment is not a directory: ${canonical}`,
-        canonical,
-      );
-    }
-    parentInode = next.inode;
+  if (parts.length === 1) return ROOT_INODE;
+
+  const parentPath = `/${parts.slice(0, -1).join("/")}`;
+  const parent = resolveInode(db, parentPath);
+  if (parent === null) {
+    throw createWorkspaceError("ENOENT", `parent directory missing: ${canonical}`, canonical);
   }
-  return parentInode;
+  if (parent.type !== "dir") {
+    throw createWorkspaceError(
+      "ENOTDIR",
+      `parent path segment is not a directory: ${canonical}`,
+      canonical,
+    );
+  }
+  return parent.inode;
 }
 
 async function materialize(content: string | Uint8Array): Promise<Uint8Array> {

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -88,6 +88,82 @@ interface ChunkRef {
   size: number;
 }
 
+type WriteTarget =
+  | { kind: "existing"; inode: number }
+  | { kind: "create"; parentInode: number; leafName: string; canonicalPath: string };
+
+function pathFromParts(parts: string[]): string {
+  return `/${parts.join("/")}`;
+}
+
+function symlinkTargetPath(target: string, linkParentParts: string[]): string {
+  if (target.startsWith("/")) return canonicalizePath(target).path;
+
+  const resolved = [...linkParentParts];
+  for (const part of target.split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      resolved.pop();
+      continue;
+    }
+    resolved.push(part);
+  }
+  return pathFromParts(resolved);
+}
+
+function resolveWriteTarget(
+  db: Database,
+  parts: string[],
+  canonical: string,
+  options: WriteFileOptions,
+): WriteTarget {
+  const parentInode = resolveParent(db, parts, canonical);
+  const leafName = parts[parts.length - 1];
+  const existing = db.one<{ child_inode: number }>(
+    "SELECT child_inode FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
+    parentInode,
+    leafName,
+  );
+
+  if (existing === undefined) {
+    return { kind: "create", parentInode, leafName, canonicalPath: canonical };
+  }
+  if (options.exclusive) {
+    throw createWorkspaceError("EEXIST", `path exists: ${canonical}`, canonical);
+  }
+
+  const node = db.one<{ type: "file" | "dir" | "symlink"; link_target: string | null }>(
+    "SELECT type, link_target FROM vfs_nodes WHERE inode = ?",
+    existing.child_inode,
+  );
+  if (node?.type === "dir") {
+    throw createWorkspaceError("EISDIR", `path is a directory: ${canonical}`, canonical);
+  }
+  if (node?.type !== "symlink") {
+    return { kind: "existing", inode: existing.child_inode };
+  }
+
+  const targetPath = symlinkTargetPath(node.link_target ?? "", parts.slice(0, -1));
+  assertNotReadOnly(db, targetPath);
+  const target = resolveInode(db, targetPath);
+  if (target === null) {
+    const { parts: targetParts, path: targetCanonical } = canonicalizePath(targetPath);
+    if (targetParts.length === 0) {
+      throw createWorkspaceError("EISDIR", "cannot write to the root directory", targetCanonical);
+    }
+    return {
+      kind: "create",
+      parentInode: resolveParent(db, targetParts, targetCanonical),
+      leafName: targetParts[targetParts.length - 1],
+      canonicalPath: targetCanonical,
+    };
+  }
+  if (target.type !== "file") {
+    throw createWorkspaceError("EISDIR", `path is a directory: ${targetPath}`, targetPath);
+  }
+  return { kind: "existing", inode: target.inode };
+}
+
 export function chunksOf(bytes: Uint8Array): PreparedChunk[] {
   const chunks: PreparedChunk[] = [];
   for (let offset = 0; offset < bytes.byteLength; offset += CHUNK_SIZE) {
@@ -242,30 +318,12 @@ export function linkStagedChunksSync(
   assertChunkWindows(chunkRefs, canonical);
   const mode = (options.mode ?? 0o644) & 0o7777;
   db.transactionSync(() => {
-    const parentInode = resolveParent(db, parts, canonical);
-    const leafName = parts[parts.length - 1];
-    const existing = db.one<{ child_inode: number }>(
-      "SELECT child_inode FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
-      parentInode,
-      leafName,
-    );
-    let inode: number;
-    if (existing !== undefined) {
-      if (options.exclusive) {
-        throw createWorkspaceError("EEXIST", `path exists: ${canonical}`, canonical);
-      }
-      const node = db.one<{ type: "file" | "dir" }>(
-        "SELECT type FROM vfs_nodes WHERE inode = ?",
-        existing.child_inode,
-      );
-      if (node?.type === "dir") {
-        throw createWorkspaceError("EISDIR", `path is a directory: ${canonical}`, canonical);
-      }
-      inode = existing.child_inode;
+    const target = resolveWriteTarget(db, parts, canonical, options);
+    const inode = target.kind === "existing" ? target.inode : insertFileNode(db, mode, mtime);
+    if (target.kind === "existing") {
       db.run("DELETE FROM vfs_chunks WHERE inode = ?", inode);
     } else {
-      inode = insertFileNode(db, mode, mtime);
-      insertFileDirent(db, parentInode, leafName, inode, canonical);
+      insertFileDirent(db, target.parentInode, target.leafName, inode, target.canonicalPath);
     }
     for (let idx = 0; idx < chunkRefs.length; idx++) {
       const ref = chunkRefs[idx];
@@ -418,17 +476,8 @@ function readChunkBytes(db: Database, inode: number, idx: number): Uint8Array {
 
 function resolveFileInode(db: Database, path: string): { inode: number; mode: number } {
   const { path: canonical } = canonicalizePath(path);
-  const node = db.one<{ inode: number; type: "file" | "dir"; mode: number }>(
-    `SELECT n.inode AS inode, n.type AS type, n.mode AS mode
-       FROM vfs_nodes n
-      WHERE n.inode = (
-        SELECT child_inode
-          FROM vfs_dirents
-         WHERE parent_inode = ? AND name = ?
-      )`,
-    ...parentAndNameForResolvedPath(db, path),
-  );
-  if (node === undefined) {
+  const node = resolveInode(db, path);
+  if (node === null) {
     throw createWorkspaceError("ENOENT", `no such file: ${canonical}`, canonical);
   }
   if (node.type !== "file") {
@@ -964,33 +1013,14 @@ export function writeFileSync(
   const mtime = now();
 
   db.transactionSync(() => {
-    const parentInode = resolveParent(db, parts, canonical);
-    const leafName = parts[parts.length - 1];
-    const existing = db.one<{ child_inode: number }>(
-      "SELECT child_inode FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
-      parentInode,
-      leafName,
-    );
-
-    let inode: number;
-    if (existing !== undefined) {
-      if (options.exclusive) {
-        throw createWorkspaceError("EEXIST", `path exists: ${canonical}`, canonical);
-      }
-      const node = db.one<{ type: "file" | "dir" }>(
-        "SELECT type FROM vfs_nodes WHERE inode = ?",
-        existing.child_inode,
-      );
-      if (node?.type === "dir") {
-        throw createWorkspaceError("EISDIR", `path is a directory: ${canonical}`, canonical);
-      }
-      inode = existing.child_inode;
+    const target = resolveWriteTarget(db, parts, canonical, options);
+    const inode = target.kind === "existing" ? target.inode : insertFileNode(db, mode, mtime);
+    if (target.kind === "existing") {
       // Replace the existing representation. Orphaned blobs (if any)
       // are cleaned up by a later gc() pass.
       db.run("DELETE FROM vfs_chunks WHERE inode = ?", inode);
     } else {
-      inode = insertFileNode(db, mode, mtime);
-      insertFileDirent(db, parentInode, leafName, inode, canonical);
+      insertFileDirent(db, target.parentInode, target.leafName, inode, target.canonicalPath);
     }
 
     const rev = incrementRev(db);
@@ -1038,29 +1068,13 @@ export function writeFileRangesSync(
   const ranges = normalizeRanges(dirtyRanges, bytes.byteLength);
   const mtime = now();
   db.transactionSync(() => {
-    const parentInode = resolveParent(db, parts, canonical);
-    const leafName = parts[parts.length - 1];
-    const existing = db.one<{ child_inode: number }>(
-      "SELECT child_inode FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
-      parentInode,
-      leafName,
-    );
-
-    let inode: number;
+    const target = resolveWriteTarget(db, parts, canonical, options);
+    const inode = target.kind === "existing" ? target.inode : insertFileNode(db, mode, mtime);
     let oldChunks: ChunkRef[] = [];
-    if (existing !== undefined) {
-      const node = db.one<{ type: "file" | "dir" }>(
-        "SELECT type FROM vfs_nodes WHERE inode = ?",
-        existing.child_inode,
-      );
-      if (node?.type === "dir") {
-        throw createWorkspaceError("EISDIR", `path is a directory: ${canonical}`, canonical);
-      }
-      inode = existing.child_inode;
+    if (target.kind === "existing") {
       oldChunks = existingChunkRefs(db, inode);
     } else {
-      inode = insertFileNode(db, mode, mtime);
-      insertFileDirent(db, parentInode, leafName, inode, canonical);
+      insertFileDirent(db, target.parentInode, target.leafName, inode, target.canonicalPath);
     }
 
     const rev = incrementRev(db);

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -17,6 +17,7 @@ import {
   ensureCapacity as ensureBufferCapacity,
   getPendingWriteBufferByPath,
   getWriteBuffer,
+  listPendingByParent,
   promotePendingToInode,
   setWriteBuffer,
   type WriteBufferEntry,
@@ -933,6 +934,30 @@ export function flushPendingByPath(db: Database, path: string, now: () => number
   if (entry === undefined || entry.pending === undefined) return false;
   commitPendingBuffer(db, entry, now);
   return true;
+}
+
+/** @internal Commits pending files below a directory before its dirent moves or disappears. */
+export function flushPendingUnderDirectory(db: Database, path: string, now: () => number): void {
+  const directory = resolveInode(db, path, { followSymlinks: false });
+  if (directory?.type !== "dir") return;
+
+  const parents = db.all<{ inode: number }>(
+    `WITH RECURSIVE descendant_dirs(inode) AS (
+      SELECT ?
+      UNION ALL
+      SELECT dirent.child_inode
+      FROM vfs_dirents AS dirent
+      JOIN descendant_dirs AS parent ON dirent.parent_inode = parent.inode
+      JOIN vfs_nodes AS node ON node.inode = dirent.child_inode
+      WHERE node.type = 'dir'
+    )
+    SELECT inode FROM descendant_dirs`,
+    directory.inode,
+  );
+  const entries = parents.flatMap(({ inode }) => listPendingByParent(db, inode));
+  for (const entry of entries) {
+    if (entry.pending !== undefined) commitPendingBuffer(db, entry, now);
+  }
 }
 
 function releasePendingBuffer(db: Database, entry: WriteBufferEntry, now: () => number): void {

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -8,7 +8,7 @@ import { stageBlob } from "../sync/blobs.js";
 import { buildManifest } from "../sync/manifests.js";
 import { pathOf } from "../sync/paths.js";
 import { getBlobBytes } from "./blobCache.js";
-import { assertNotReadOnly } from "./mount-guard.js";
+import { assertNotInReadOnlyMount, assertNotReadOnly } from "./mount-guard.js";
 import { invalidateResolveExact } from "./resolveCache.js";
 import {
   allocatePendingInode,
@@ -92,7 +92,7 @@ function resolveParent(
       countSymlinkFollow(follows, canonical);
       const target = node.link_target ?? "";
       const targetParts = symlinkTargetParts(target, realParts);
-      assertNotReadOnly(db, clampedPathFromParts(targetParts));
+      assertNotInReadOnlyMount(db, clampedPathFromParts(targetParts));
       if (target.startsWith("/")) {
         inodeStack.splice(1);
         realParts.splice(0);
@@ -275,7 +275,7 @@ function resolveWriteTarget(
     const realLinkParts = canonicalizePath(direct.canonicalPath).parts;
     targetParts = symlinkTargetParts(node.link_target ?? "", realLinkParts.slice(0, -1));
     targetCanonical = clampedPathFromParts(targetParts);
-    assertNotReadOnly(db, targetCanonical);
+    assertNotInReadOnlyMount(db, targetCanonical);
     const finalPart = targetParts.at(-1);
     if (finalPart === undefined || finalPart === "" || finalPart === "." || finalPart === "..") {
       resolveParent(db, [...targetParts, "__write_target__"], targetCanonical, follows);

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -9,6 +9,7 @@ import { buildManifest } from "../sync/manifests.js";
 import { pathOf } from "../sync/paths.js";
 import { getBlobBytes } from "./blobCache.js";
 import { assertNotInReadOnlyMount, assertNotReadOnly } from "./mount-guard.js";
+import { findPendingWriteBuffer } from "./pendingWriteBuffer.js";
 import { resolveInode } from "./resolve.js";
 import { invalidateResolveExact } from "./resolveCache.js";
 import {
@@ -724,7 +725,7 @@ export function createFileSync(
 // the bytes back to chunks.
 export function openWriteBufferSync(db: Database, path: string): void {
   const { path: canonical } = canonicalizePath(path);
-  const pending = getPendingWriteBufferByPath(db, canonical);
+  const pending = findPendingWriteBuffer(db, canonical);
   if (pending !== undefined) {
     pending.openCount += 1;
     return;
@@ -798,7 +799,7 @@ export function openWriteBufferForCreateSync(
 // emit their INSERT + dirent + chunks in the same transaction.
 export function releaseWriteBufferSync(db: Database, path: string, now: () => number): void {
   const { path: canonical } = canonicalizePath(path);
-  const pending = getPendingWriteBufferByPath(db, canonical);
+  const pending = findPendingWriteBuffer(db, canonical);
   if (pending !== undefined) {
     releasePendingBuffer(db, pending, now);
     return;
@@ -943,7 +944,7 @@ function commitPendingBuffer(db: Database, entry: WriteBufferEntry, now: () => n
  */
 export function flushPendingByPath(db: Database, path: string, now: () => number): boolean {
   const { path: canonical } = canonicalizePath(path);
-  const entry = getPendingWriteBufferByPath(db, canonical);
+  const entry = findPendingWriteBuffer(db, canonical);
   if (entry === undefined || entry.pending === undefined) return false;
   commitPendingBuffer(db, entry, now);
   return true;
@@ -1012,7 +1013,7 @@ export function writeRangeSync(
 
   // Pending-create files don't have an inode yet; route the write
   // straight into the path-keyed buffer.
-  const pending = getPendingWriteBufferByPath(db, canonical);
+  const pending = findPendingWriteBuffer(db, canonical);
   if (pending !== undefined) {
     assertNotReadOnly(db, pendingTargetPath(pending, canonical));
     const writeEnd = offset + bytes.byteLength;
@@ -1090,7 +1091,7 @@ export function truncateFileSync(
   const mtime = now();
 
   // Pending-create files truncate in-place on the path-keyed buffer.
-  const pending = getPendingWriteBufferByPath(db, canonical);
+  const pending = findPendingWriteBuffer(db, canonical);
   if (pending !== undefined) {
     assertNotReadOnly(db, pendingTargetPath(pending, canonical));
     if (size > pending.size) {

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -759,7 +759,10 @@ export function openWriteBufferForCreateSync(
     throw createWorkspaceError("EEXIST", `path exists: ${canonical}`, canonical);
   }
   const target = directTargetForPath(db, path);
-  if (target.existingInode !== undefined) {
+  if (
+    target.existingInode !== undefined ||
+    getPendingWriteBufferByPath(db, target.canonicalPath) !== undefined
+  ) {
     throw createWorkspaceError("EEXIST", `path exists: ${canonical}`, canonical);
   }
   const mode = (options.mode ?? 0o644) & 0o7777;
@@ -775,6 +778,7 @@ export function openWriteBufferForCreateSync(
       parentInode: target.parentInode,
       leafName: target.leafName,
       canonicalPath: canonical,
+      resolvedPath: target.canonicalPath,
       pendingInode,
       mtime,
     },

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -91,6 +91,8 @@ function resolveParent(
     if (node.type === "symlink") {
       countSymlinkFollow(follows, canonical);
       const target = node.link_target ?? "";
+      const targetParts = symlinkTargetParts(target, realParts);
+      assertNotReadOnly(db, canonicalizePath(pathFromParts(targetParts)).path);
       if (target.startsWith("/")) {
         inodeStack.splice(1);
         realParts.splice(0);
@@ -177,6 +179,13 @@ function childPath(db: Database, parentInode: number, leafName: string, path: st
   return parentPath === "/" ? `/${leafName}` : `${parentPath}/${leafName}`;
 }
 
+function pendingTargetPath(db: Database, entry: WriteBufferEntry, fallback: string): string {
+  const pending = entry.pending;
+  return pending === undefined
+    ? fallback
+    : childPath(db, pending.parentInode, pending.leafName, pending.canonicalPath);
+}
+
 function symlinkTargetParts(target: string, linkParentParts: string[]): string[] {
   const base = target.startsWith("/") ? [] : linkParentParts;
   return [...base, ...target.split("/")];
@@ -192,6 +201,7 @@ function resolveDirectWriteTarget(
   const leafName = parts[parts.length - 1];
   const canonicalPath =
     parent.canonicalPath === "/" ? `/${leafName}` : `${parent.canonicalPath}/${leafName}`;
+  assertNotReadOnly(db, canonicalPath);
   const existing = db.one<{ child_inode: number }>(
     "SELECT child_inode FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
     parent.inode,
@@ -214,6 +224,7 @@ function resolveWriteTarget(
   let targetParts = parts;
   let targetCanonical = canonical;
   const follows = { count: 0 };
+  assertNotReadOnly(db, canonical);
 
   while (true) {
     const direct = resolveDirectWriteTarget(db, targetParts, targetCanonical, follows);
@@ -251,6 +262,7 @@ function resolveWriteTarget(
     const realLinkParts = canonicalizePath(direct.canonicalPath).parts;
     targetParts = symlinkTargetParts(node.link_target ?? "", realLinkParts.slice(0, -1));
     targetCanonical = canonicalizePath(pathFromParts(targetParts)).path;
+    assertNotReadOnly(db, targetCanonical);
     const finalPart = targetParts.at(-1);
     if (finalPart === undefined || finalPart === "" || finalPart === "." || finalPart === "..") {
       resolveParent(db, [...targetParts, "__write_target__"], targetCanonical, follows);
@@ -309,8 +321,8 @@ async function writeFileStreaming(
     throw createWorkspaceError("EISDIR", "cannot write to the root directory", canonical);
   }
   // Reject before we stage any blob bytes so known failures do not grow
-  // orphan blob rows that gc() then has to reap.
-  assertNotReadOnly(db, canonical);
+  // orphan blob rows that gc() then has to reap. Resolve both lexical and
+  // effective paths so a symlink cannot defer an EROFS failure until commit.
   resolveWriteTarget(db, parts, canonical, options);
   const mode = (options.mode ?? 0o644) & 0o7777;
   const mtime = now();
@@ -681,8 +693,10 @@ export function createFileSync(
 // the bytes back to chunks.
 export function openWriteBufferSync(db: Database, path: string): void {
   const { path: canonical } = canonicalizePath(path);
+  assertNotReadOnly(db, canonical);
   const pending = getPendingWriteBufferByPath(db, canonical);
   if (pending !== undefined) {
+    assertNotReadOnly(db, pendingTargetPath(db, pending, canonical));
     pending.openCount += 1;
     return;
   }
@@ -816,7 +830,9 @@ function commitPendingBuffer(db: Database, entry: WriteBufferEntry, now: () => n
   let realInode = 0;
   try {
     db.transactionSync(() => {
+      assertNotReadOnly(db, canonicalPath);
       const targetPath = childPath(db, parentInode, leafName, canonicalPath);
+      assertNotReadOnly(db, targetPath);
       // Re-check at commit time: a non-buffered writeFile or another
       // out-of-band path could have landed between open and release.
       const collision = db.one<{ child_inode: number }>(
@@ -946,6 +962,7 @@ export function writeRangeSync(
   // straight into the path-keyed buffer.
   const pending = getPendingWriteBufferByPath(db, canonical);
   if (pending !== undefined) {
+    assertNotReadOnly(db, pendingTargetPath(db, pending, canonical));
     const writeEnd = offset + bytes.byteLength;
     ensureBufferCapacity(pending, writeEnd);
     if (offset > pending.size) {
@@ -1023,6 +1040,7 @@ export function truncateFileSync(
   // Pending-create files truncate in-place on the path-keyed buffer.
   const pending = getPendingWriteBufferByPath(db, canonical);
   if (pending !== undefined) {
+    assertNotReadOnly(db, pendingTargetPath(db, pending, canonical));
     if (size > pending.size) {
       ensureBufferCapacity(pending, size);
       pending.buf.fill(0, pending.size, size);

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -154,7 +154,7 @@ interface ChunkRef {
 }
 
 type WriteTarget =
-  | { kind: "existing"; inode: number }
+  | { kind: "existing"; inode: number; canonicalPath: string }
   | { kind: "create"; parentInode: number; leafName: string; canonicalPath: string };
 
 interface DirectWriteTarget {
@@ -275,7 +275,11 @@ function resolveWriteTarget(
       );
     }
     if (node.type !== "symlink") {
-      return { kind: "existing", inode: direct.existingInode };
+      return {
+        kind: "existing",
+        inode: direct.existingInode,
+        canonicalPath: direct.canonicalPath,
+      };
     }
 
     countSymlinkFollow(follows, canonical);
@@ -603,7 +607,10 @@ function resolveFileInode(db: Database, path: string): { inode: number; mode: nu
   return { inode: node.inode, mode: node.mode };
 }
 
-function resolveWritableFileInode(db: Database, path: string): { inode: number; mode: number } {
+function resolveWritableFileInode(
+  db: Database,
+  path: string,
+): { inode: number; mode: number; canonicalPath: string } {
   const { parts, path: canonical } = canonicalizePath(path);
   if (parts.length === 0) {
     throw createWorkspaceError("EISDIR", "cannot write to the root directory", canonical);
@@ -616,7 +623,7 @@ function resolveWritableFileInode(db: Database, path: string): { inode: number; 
   if (mode === undefined) {
     throw createWorkspaceError("ENOENT", `no such file: ${canonical}`, canonical);
   }
-  return { inode: target.inode, mode };
+  return { inode: target.inode, mode, canonicalPath: target.canonicalPath };
 }
 
 function directTargetForPath(db: Database, path: string): DirectWriteTarget {
@@ -820,7 +827,11 @@ export function releaseWriteBufferSync(db: Database, path: string, now: () => nu
   const buffered = entry.buf.subarray(0, entry.size);
 
   try {
-    resolveWritableFileInode(db, path);
+    if (entry.dirtyPath === undefined || entry.dirtyTargetPath === undefined) {
+      throw createWorkspaceError("EIO", `buffer has no writable path: ${canonical}`, canonical);
+    }
+    assertNotReadOnly(db, entry.dirtyPath);
+    assertNotReadOnly(db, entry.dirtyTargetPath);
     db.transactionSync(() => {
       if (entry.size === 0) {
         // An empty file owns no chunk rows; clear any old ones the
@@ -931,6 +942,7 @@ function commitPendingBuffer(db: Database, entry: WriteBufferEntry, now: () => n
     throw error;
   }
   promotePendingToInode(db, pendingInode, realInode);
+  entry.dirty = false;
   return realInode;
 }
 
@@ -1028,7 +1040,11 @@ export function writeRangeSync(
     return bytes.byteLength;
   }
 
-  const { inode, mode: existingMode } = resolveWritableFileInode(db, path);
+  const {
+    inode,
+    mode: existingMode,
+    canonicalPath: targetPath,
+  } = resolveWritableFileInode(db, path);
   const mode = (options.mode ?? existingMode) & 0o7777;
   const buffered = getWriteBuffer(db, inode);
 
@@ -1046,6 +1062,8 @@ export function writeRangeSync(
     if (writeEnd > buffered.size) buffered.size = writeEnd;
     buffered.mode = mode;
     buffered.dirty = true;
+    buffered.dirtyPath = canonical;
+    buffered.dirtyTargetPath = targetPath;
     return bytes.byteLength;
   }
 
@@ -1103,7 +1121,7 @@ export function truncateFileSync(
     return;
   }
 
-  const { inode, mode } = resolveWritableFileInode(db, path);
+  const { inode, mode, canonicalPath: targetPath } = resolveWritableFileInode(db, path);
   const buffered = getWriteBuffer(db, inode);
 
   if (buffered !== undefined) {
@@ -1114,6 +1132,8 @@ export function truncateFileSync(
     }
     buffered.size = size;
     buffered.dirty = true;
+    buffered.dirtyPath = canonical;
+    buffered.dirtyTargetPath = targetPath;
     return;
   }
 

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -8,7 +8,6 @@ import { stageBlob } from "../sync/blobs.js";
 import { buildManifest } from "../sync/manifests.js";
 import { getBlobBytes } from "./blobCache.js";
 import { assertNotReadOnly } from "./mount-guard.js";
-import { resolveInode } from "./resolve.js";
 import { invalidateResolveExact } from "./resolveCache.js";
 import {
   allocatePendingInode,
@@ -38,26 +37,81 @@ export interface WriteFileRange {
   end: number;
 }
 
-// Resolve directory-only paths (the parent of the target file). The
-// final segment is handled by the caller. Resolve each prefix so a
-// missing segment remains distinguishable from a non-directory segment.
-function resolveParent(db: Database, parts: string[], canonical: string): number {
-  let parentInode = ROOT_INODE;
-  for (let depth = 1; depth < parts.length; depth++) {
-    const parent = resolveInode(db, `/${parts.slice(0, depth).join("/")}`);
-    if (parent === null) {
+interface SymlinkFollowState {
+  count: number;
+}
+
+interface ResolvedParent {
+  inode: number;
+  canonicalPath: string;
+}
+
+// Resolve the target's parent one component at a time. Expanding links
+// here preserves ENOTDIR errors and lets final and intermediate links
+// share one follow limit.
+function resolveParent(
+  db: Database,
+  parts: string[],
+  canonical: string,
+  follows: SymlinkFollowState,
+): ResolvedParent {
+  const pendingParts = parts.slice(0, -1);
+  const inodeStack = [ROOT_INODE];
+  const realParts: string[] = [];
+
+  while (pendingParts.length > 0) {
+    const name = pendingParts.shift();
+    if (name === undefined || name === "" || name === ".") continue;
+    if (name === "..") {
+      if (inodeStack.length > 1) {
+        inodeStack.pop();
+        realParts.pop();
+      }
+      continue;
+    }
+
+    const parentInode = inodeStack[inodeStack.length - 1];
+    const child = db.one<{ child_inode: number }>(
+      "SELECT child_inode FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
+      parentInode,
+      name,
+    );
+    if (child === undefined) {
       throw createWorkspaceError("ENOENT", `parent directory missing: ${canonical}`, canonical);
     }
-    if (parent.type !== "dir") {
+    const node = db.one<{
+      inode: number;
+      type: "file" | "dir" | "symlink";
+      link_target: string | null;
+    }>("SELECT inode, type, link_target FROM vfs_nodes WHERE inode = ?", child.child_inode);
+    if (node === undefined) {
+      throw createWorkspaceError("ENOENT", `dangling dirent: ${canonical}`, canonical);
+    }
+    if (node.type === "symlink") {
+      countSymlinkFollow(follows, canonical);
+      const target = node.link_target ?? "";
+      if (target.startsWith("/")) {
+        inodeStack.splice(1);
+        realParts.splice(0);
+      }
+      pendingParts.unshift(...target.split("/"));
+      continue;
+    }
+    if (node.type !== "dir") {
       throw createWorkspaceError(
         "ENOTDIR",
         `parent path segment is not a directory: ${canonical}`,
         canonical,
       );
     }
-    parentInode = parent.inode;
+    inodeStack.push(node.inode);
+    realParts.push(name);
   }
-  return parentInode;
+
+  return {
+    inode: inodeStack[inodeStack.length - 1],
+    canonicalPath: pathFromParts(realParts),
+  };
 }
 
 async function materialize(content: string | Uint8Array): Promise<Uint8Array> {
@@ -92,23 +146,54 @@ type WriteTarget =
   | { kind: "existing"; inode: number }
   | { kind: "create"; parentInode: number; leafName: string; canonicalPath: string };
 
+interface DirectWriteTarget {
+  parentInode: number;
+  leafName: string;
+  canonicalPath: string;
+  existingInode?: number;
+}
+
+// Match resolveInode's Linux-compatible cap. Final symlinks are
+// unwound here because a dangling chain must create its last target.
+const MAX_SYMLINK_FOLLOWS = 40;
+
+function countSymlinkFollow(follows: SymlinkFollowState, path: string): void {
+  follows.count += 1;
+  if (follows.count > MAX_SYMLINK_FOLLOWS) {
+    throw createWorkspaceError("ELOOP", "too many symlinks resolving path", path);
+  }
+}
+
 function pathFromParts(parts: string[]): string {
   return `/${parts.join("/")}`;
 }
 
-function symlinkTargetPath(target: string, linkParentParts: string[]): string {
-  if (target.startsWith("/")) return canonicalizePath(target).path;
+function symlinkTargetParts(target: string, linkParentParts: string[]): string[] {
+  const base = target.startsWith("/") ? [] : linkParentParts;
+  return [...base, ...target.split("/")];
+}
 
-  const resolved = [...linkParentParts];
-  for (const part of target.split("/")) {
-    if (part === "" || part === ".") continue;
-    if (part === "..") {
-      resolved.pop();
-      continue;
-    }
-    resolved.push(part);
-  }
-  return pathFromParts(resolved);
+function resolveDirectWriteTarget(
+  db: Database,
+  parts: string[],
+  canonical: string,
+  follows: SymlinkFollowState = { count: 0 },
+): DirectWriteTarget {
+  const parent = resolveParent(db, parts, canonical, follows);
+  const leafName = parts[parts.length - 1];
+  const canonicalPath =
+    parent.canonicalPath === "/" ? `/${leafName}` : `${parent.canonicalPath}/${leafName}`;
+  const existing = db.one<{ child_inode: number }>(
+    "SELECT child_inode FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
+    parent.inode,
+    leafName,
+  );
+  return {
+    parentInode: parent.inode,
+    leafName,
+    canonicalPath,
+    existingInode: existing?.child_inode,
+  };
 }
 
 function resolveWriteTarget(
@@ -117,51 +202,52 @@ function resolveWriteTarget(
   canonical: string,
   options: WriteFileOptions,
 ): WriteTarget {
-  const parentInode = resolveParent(db, parts, canonical);
-  const leafName = parts[parts.length - 1];
-  const existing = db.one<{ child_inode: number }>(
-    "SELECT child_inode FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
-    parentInode,
-    leafName,
-  );
+  let targetParts = parts;
+  let targetCanonical = canonical;
+  const follows = { count: 0 };
 
-  if (existing === undefined) {
-    return { kind: "create", parentInode, leafName, canonicalPath: canonical };
-  }
-  if (options.exclusive) {
-    throw createWorkspaceError("EEXIST", `path exists: ${canonical}`, canonical);
-  }
-
-  const node = db.one<{ type: "file" | "dir" | "symlink"; link_target: string | null }>(
-    "SELECT type, link_target FROM vfs_nodes WHERE inode = ?",
-    existing.child_inode,
-  );
-  if (node?.type === "dir") {
-    throw createWorkspaceError("EISDIR", `path is a directory: ${canonical}`, canonical);
-  }
-  if (node?.type !== "symlink") {
-    return { kind: "existing", inode: existing.child_inode };
-  }
-
-  const targetPath = symlinkTargetPath(node.link_target ?? "", parts.slice(0, -1));
-  assertNotReadOnly(db, targetPath);
-  const target = resolveInode(db, targetPath);
-  if (target === null) {
-    const { parts: targetParts, path: targetCanonical } = canonicalizePath(targetPath);
-    if (targetParts.length === 0) {
-      throw createWorkspaceError("EISDIR", "cannot write to the root directory", targetCanonical);
+  while (true) {
+    const direct = resolveDirectWriteTarget(db, targetParts, targetCanonical, follows);
+    if (direct.existingInode === undefined) {
+      return {
+        kind: "create",
+        parentInode: direct.parentInode,
+        leafName: direct.leafName,
+        canonicalPath: targetCanonical,
+      };
     }
-    return {
-      kind: "create",
-      parentInode: resolveParent(db, targetParts, targetCanonical),
-      leafName: targetParts[targetParts.length - 1],
-      canonicalPath: targetCanonical,
-    };
+    if (options.exclusive) {
+      throw createWorkspaceError("EEXIST", `path exists: ${canonical}`, canonical);
+    }
+
+    const node = db.one<{ type: "file" | "dir" | "symlink"; link_target: string | null }>(
+      "SELECT type, link_target FROM vfs_nodes WHERE inode = ?",
+      direct.existingInode,
+    );
+    if (node === undefined) {
+      throw createWorkspaceError("ENOENT", `dangling dirent: ${targetCanonical}`, targetCanonical);
+    }
+    if (node.type === "dir") {
+      throw createWorkspaceError(
+        "EISDIR",
+        `path is a directory: ${targetCanonical}`,
+        targetCanonical,
+      );
+    }
+    if (node.type !== "symlink") {
+      return { kind: "existing", inode: direct.existingInode };
+    }
+
+    countSymlinkFollow(follows, canonical);
+    const realLinkParts = canonicalizePath(direct.canonicalPath).parts;
+    targetParts = symlinkTargetParts(node.link_target ?? "", realLinkParts.slice(0, -1));
+    targetCanonical = canonicalizePath(pathFromParts(targetParts)).path;
+    const finalPart = targetParts.at(-1);
+    if (finalPart === undefined || finalPart === "" || finalPart === "." || finalPart === "..") {
+      resolveParent(db, [...targetParts, "__write_target__"], targetCanonical, follows);
+      throw createWorkspaceError("EISDIR", "path is a directory", targetCanonical);
+    }
   }
-  if (target.type !== "file") {
-    throw createWorkspaceError("EISDIR", `path is a directory: ${targetPath}`, targetPath);
-  }
-  return { kind: "existing", inode: target.inode };
 }
 
 export function chunksOf(bytes: Uint8Array): PreparedChunk[] {
@@ -216,17 +302,7 @@ async function writeFileStreaming(
   // Reject before we stage any blob bytes so known failures do not grow
   // orphan blob rows that gc() then has to reap.
   assertNotReadOnly(db, canonical);
-  if (options.exclusive) {
-    const parentInode = resolveParent(db, parts, canonical);
-    const existing = db.one(
-      "SELECT 1 FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
-      parentInode,
-      parts[parts.length - 1],
-    );
-    if (existing !== undefined) {
-      throw createWorkspaceError("EEXIST", `path exists: ${canonical}`, canonical);
-    }
-  }
+  resolveWriteTarget(db, parts, canonical, options);
   const mode = (options.mode ?? 0o644) & 0o7777;
   const mtime = now();
 
@@ -475,23 +551,28 @@ function readChunkBytes(db: Database, inode: number, idx: number): Uint8Array {
 }
 
 function resolveFileInode(db: Database, path: string): { inode: number; mode: number } {
-  const { path: canonical } = canonicalizePath(path);
-  const node = resolveInode(db, path);
-  if (node === null) {
-    throw createWorkspaceError("ENOENT", `no such file: ${canonical}`, canonical);
-  }
-  if (node.type !== "file") {
-    throw createWorkspaceError("EISDIR", `path is a directory: ${canonical}`, canonical);
-  }
-  return { inode: node.inode, mode: node.mode };
-}
-
-function parentAndNameForResolvedPath(db: Database, path: string): [number, string] {
   const { parts, path: canonical } = canonicalizePath(path);
   if (parts.length === 0) {
     throw createWorkspaceError("EISDIR", "cannot write to the root directory", canonical);
   }
-  return [resolveParent(db, parts, canonical), parts[parts.length - 1]];
+  const target = resolveWriteTarget(db, parts, canonical, {});
+  if (target.kind === "create") {
+    throw createWorkspaceError("ENOENT", `no such file: ${canonical}`, canonical);
+  }
+  const mode = db.scalar<number>("SELECT mode FROM vfs_nodes WHERE inode = ?", target.inode);
+  if (mode === undefined) {
+    throw createWorkspaceError("ENOENT", `no such file: ${canonical}`, canonical);
+  }
+  return { inode: target.inode, mode };
+}
+
+function directTargetForPath(db: Database, path: string): DirectWriteTarget {
+  const { parts, path: canonical } = canonicalizePath(path);
+  if (parts.length === 0) {
+    throw createWorkspaceError("EISDIR", "cannot write to the root directory", canonical);
+  }
+  assertNotReadOnly(db, canonical);
+  return resolveDirectWriteTarget(db, parts, canonical);
 }
 
 // Update an inode's chunk-backed representation in place. Iterates over
@@ -562,18 +643,12 @@ export function createFileSync(
   now: () => number,
 ): void {
   const { path: canonical } = canonicalizePath(path);
-  assertNotReadOnly(db, canonical);
-  const [parentInode, leafName] = parentAndNameForResolvedPath(db, path);
+  const target = directTargetForPath(db, path);
   const mode = (options.mode ?? 0o644) & 0o7777;
   const mtime = now();
 
   db.transactionSync(() => {
-    const existing = db.one<{ child_inode: number }>(
-      "SELECT child_inode FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
-      parentInode,
-      leafName,
-    );
-    if (existing !== undefined) {
+    if (target.existingInode !== undefined) {
       throw createWorkspaceError("EEXIST", `path exists: ${canonical}`, canonical);
     }
     const rev = incrementRev(db);
@@ -587,7 +662,7 @@ export function createFileSync(
       rev,
     );
     if (row === undefined) throw createWorkspaceError("EIO", "failed to allocate inode");
-    insertFileDirent(db, parentInode, leafName, row.inode, canonical);
+    insertFileDirent(db, target.parentInode, target.leafName, row.inode, canonical);
   });
 }
 
@@ -633,17 +708,11 @@ export function openWriteBufferForCreateSync(
   now: () => number,
 ): void {
   const { path: canonical } = canonicalizePath(path);
-  assertNotReadOnly(db, canonical);
   if (getPendingWriteBufferByPath(db, canonical) !== undefined) {
     throw createWorkspaceError("EEXIST", `path exists: ${canonical}`, canonical);
   }
-  const [parentInode, leafName] = parentAndNameForResolvedPath(db, path);
-  const existing = db.one<{ child_inode: number }>(
-    "SELECT child_inode FROM vfs_dirents WHERE parent_inode = ? AND name = ?",
-    parentInode,
-    leafName,
-  );
-  if (existing !== undefined) {
+  const target = directTargetForPath(db, path);
+  if (target.existingInode !== undefined) {
     throw createWorkspaceError("EEXIST", `path exists: ${canonical}`, canonical);
   }
   const mode = (options.mode ?? 0o644) & 0o7777;
@@ -655,7 +724,13 @@ export function openWriteBufferForCreateSync(
     dirty: true,
     openCount: 1,
     mode,
-    pending: { parentInode, leafName, canonicalPath: canonical, pendingInode, mtime },
+    pending: {
+      parentInode: target.parentInode,
+      leafName: target.leafName,
+      canonicalPath: canonical,
+      pendingInode,
+      mtime,
+    },
   });
 }
 

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -39,25 +39,25 @@ export interface WriteFileRange {
 }
 
 // Resolve directory-only paths (the parent of the target file). The
-// final segment is handled by the caller. Returns the parent inode or
-// throws ENOENT/ENOTDIR. Intermediate symlinks are followed by the
-// normal resolver so writes match read/path-resolution semantics.
+// final segment is handled by the caller. Resolve each prefix so a
+// missing segment remains distinguishable from a non-directory segment.
 function resolveParent(db: Database, parts: string[], canonical: string): number {
-  if (parts.length === 1) return ROOT_INODE;
-
-  const parentPath = `/${parts.slice(0, -1).join("/")}`;
-  const parent = resolveInode(db, parentPath);
-  if (parent === null) {
-    throw createWorkspaceError("ENOENT", `parent directory missing: ${canonical}`, canonical);
+  let parentInode = ROOT_INODE;
+  for (let depth = 1; depth < parts.length; depth++) {
+    const parent = resolveInode(db, `/${parts.slice(0, depth).join("/")}`);
+    if (parent === null) {
+      throw createWorkspaceError("ENOENT", `parent directory missing: ${canonical}`, canonical);
+    }
+    if (parent.type !== "dir") {
+      throw createWorkspaceError(
+        "ENOTDIR",
+        `parent path segment is not a directory: ${canonical}`,
+        canonical,
+      );
+    }
+    parentInode = parent.inode;
   }
-  if (parent.type !== "dir") {
-    throw createWorkspaceError(
-      "ENOTDIR",
-      `parent path segment is not a directory: ${canonical}`,
-      canonical,
-    );
-  }
-  return parent.inode;
+  return parentInode;
 }
 
 async function materialize(content: string | Uint8Array): Promise<Uint8Array> {

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -806,36 +806,41 @@ export function releaseWriteBufferSync(db: Database, path: string, now: () => nu
     return;
   }
 
-  resolveWritableFileInode(db, path);
   const mtime = now();
   const mode = entry.mode & 0o7777;
   const buffered = entry.buf.subarray(0, entry.size);
 
-  db.transactionSync(() => {
-    if (entry.size === 0) {
-      // An empty file owns no chunk rows; clear any old ones the
-      // buffer would otherwise have replaced and bump metadata.
-      db.run("DELETE FROM vfs_chunks WHERE inode = ?", node.inode);
-      const rev = incrementRev(db);
-      db.run(
-        "UPDATE vfs_nodes SET mode = ?, mtime = ?, rev = ?, size = 0, manifest_hash = NULL WHERE inode = ?",
+  try {
+    resolveWritableFileInode(db, path);
+    db.transactionSync(() => {
+      if (entry.size === 0) {
+        // An empty file owns no chunk rows; clear any old ones the
+        // buffer would otherwise have replaced and bump metadata.
+        db.run("DELETE FROM vfs_chunks WHERE inode = ?", node.inode);
+        const rev = incrementRev(db);
+        db.run(
+          "UPDATE vfs_nodes SET mode = ?, mtime = ?, rev = ?, size = 0, manifest_hash = NULL WHERE inode = ?",
+          mode,
+          mtime,
+          rev,
+          node.inode,
+        );
+        return;
+      }
+      applyChunkedInodeUpdate(
+        db,
+        node.inode,
+        entry.size,
         mode,
         mtime,
-        rev,
-        node.inode,
+        (_idx, start, end) => start < entry.size && end > 0,
+        (_idx, start, end) => buffered.subarray(start, Math.min(end, entry.size)),
       );
-      return;
-    }
-    applyChunkedInodeUpdate(
-      db,
-      node.inode,
-      entry.size,
-      mode,
-      mtime,
-      (_idx, start, end) => start < entry.size && end > 0,
-      (_idx, start, end) => buffered.subarray(start, Math.min(end, entry.size)),
-    );
-  });
+    });
+  } catch (error) {
+    deleteWriteBuffer(db, node.inode);
+    throw error;
+  }
 
   deleteWriteBuffer(db, node.inode);
 }

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -9,6 +9,7 @@ import { buildManifest } from "../sync/manifests.js";
 import { pathOf } from "../sync/paths.js";
 import { getBlobBytes } from "./blobCache.js";
 import { assertNotInReadOnlyMount, assertNotReadOnly } from "./mount-guard.js";
+import { resolveInode } from "./resolve.js";
 import { invalidateResolveExact } from "./resolveCache.js";
 import {
   allocatePendingInode,
@@ -585,6 +586,18 @@ function readChunkBytes(db: Database, inode: number, idx: number): Uint8Array {
 }
 
 function resolveFileInode(db: Database, path: string): { inode: number; mode: number } {
+  const { path: canonical } = canonicalizePath(path);
+  const node = resolveInode(db, canonical);
+  if (node === null) {
+    throw createWorkspaceError("ENOENT", `no such file: ${canonical}`, canonical);
+  }
+  if (node.type !== "file") {
+    throw createWorkspaceError("EISDIR", `path is a directory: ${canonical}`, canonical);
+  }
+  return { inode: node.inode, mode: node.mode };
+}
+
+function resolveWritableFileInode(db: Database, path: string): { inode: number; mode: number } {
   const { parts, path: canonical } = canonicalizePath(path);
   if (parts.length === 0) {
     throw createWorkspaceError("EISDIR", "cannot write to the root directory", canonical);
@@ -706,10 +719,8 @@ export function createFileSync(
 // the bytes back to chunks.
 export function openWriteBufferSync(db: Database, path: string): void {
   const { path: canonical } = canonicalizePath(path);
-  assertNotReadOnly(db, canonical);
   const pending = getPendingWriteBufferByPath(db, canonical);
   if (pending !== undefined) {
-    assertNotReadOnly(db, pendingTargetPath(db, pending, canonical));
     pending.openCount += 1;
     return;
   }
@@ -793,6 +804,7 @@ export function releaseWriteBufferSync(db: Database, path: string, now: () => nu
     return;
   }
 
+  resolveWritableFileInode(db, path);
   const mtime = now();
   const mode = entry.mode & 0o7777;
   const buffered = entry.buf.subarray(0, entry.size);
@@ -988,7 +1000,7 @@ export function writeRangeSync(
     return bytes.byteLength;
   }
 
-  const { inode, mode: existingMode } = resolveFileInode(db, path);
+  const { inode, mode: existingMode } = resolveWritableFileInode(db, path);
   const mode = (options.mode ?? existingMode) & 0o7777;
   const buffered = getWriteBuffer(db, inode);
 
@@ -1063,7 +1075,7 @@ export function truncateFileSync(
     return;
   }
 
-  const { inode, mode } = resolveFileInode(db, path);
+  const { inode, mode } = resolveWritableFileInode(db, path);
   const buffered = getWriteBuffer(db, inode);
 
   if (buffered !== undefined) {

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -47,6 +47,7 @@ interface SymlinkFollowState {
 interface ResolvedParent {
   inode: number;
   canonicalPath: string;
+  ancestorInodes: number[];
 }
 
 // Resolve the target's parent one component at a time. Expanding links
@@ -61,6 +62,7 @@ function resolveParent(
   const pendingParts = parts.slice(0, -1);
   const inodeStack = [ROOT_INODE];
   const realParts: string[] = [];
+  const ancestorInodes = new Set([ROOT_INODE]);
 
   while (pendingParts.length > 0) {
     const name = pendingParts.shift();
@@ -111,11 +113,13 @@ function resolveParent(
     }
     inodeStack.push(node.inode);
     realParts.push(name);
+    ancestorInodes.add(node.inode);
   }
 
   return {
     inode: inodeStack[inodeStack.length - 1],
     canonicalPath: pathFromParts(realParts),
+    ancestorInodes: [...ancestorInodes],
   };
 }
 
@@ -155,6 +159,7 @@ interface DirectWriteTarget {
   parentInode: number;
   leafName: string;
   canonicalPath: string;
+  ancestorInodes: number[];
   existingInode?: number;
 }
 
@@ -223,6 +228,7 @@ function resolveDirectWriteTarget(
     parentInode: parent.inode,
     leafName,
     canonicalPath,
+    ancestorInodes: parent.ancestorInodes,
     existingInode: existing?.child_inode,
   };
 }
@@ -777,6 +783,7 @@ export function openWriteBufferForCreateSync(
       leafName: target.leafName,
       canonicalPath: canonical,
       resolvedPath: target.canonicalPath,
+      ancestorInodes: target.ancestorInodes,
       pendingInode,
       mtime,
     },
@@ -946,12 +953,10 @@ export function flushPendingUnderDirectory(db: Database, path: string, now: () =
   const directory = resolveInode(db, path, { followSymlinks: false });
   if (directory?.type !== "dir") return;
 
-  // A pending file can be lexically beneath this directory while its
-  // resolved parent is elsewhere through a symlink, and either path
-  // may itself have multiple aliases. Structural changes are rare, so
-  // commit every pending create rather than leave an alias stale.
   for (const entry of listPendingWriteBuffers(db)) {
-    if (entry.pending !== undefined) commitPendingBuffer(db, entry, now);
+    if (entry.pending?.ancestorInodes.includes(directory.inode)) {
+      commitPendingBuffer(db, entry, now);
+    }
   }
 }
 

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -6,6 +6,7 @@ import { ROOT_INODE } from "../schema/index.js";
 import type { Database } from "../storage.js";
 import { stageBlob } from "../sync/blobs.js";
 import { buildManifest } from "../sync/manifests.js";
+import { pathOf } from "../sync/paths.js";
 import { getBlobBytes } from "./blobCache.js";
 import { assertNotReadOnly } from "./mount-guard.js";
 import { invalidateResolveExact } from "./resolveCache.js";
@@ -168,6 +169,14 @@ function pathFromParts(parts: string[]): string {
   return `/${parts.join("/")}`;
 }
 
+function childPath(db: Database, parentInode: number, leafName: string, path: string): string {
+  const parentPath = pathOf(db, parentInode);
+  if (parentPath === null) {
+    throw createWorkspaceError("ENOENT", `parent directory missing: ${path}`, path);
+  }
+  return parentPath === "/" ? `/${leafName}` : `${parentPath}/${leafName}`;
+}
+
 function symlinkTargetParts(target: string, linkParentParts: string[]): string[] {
   const base = target.startsWith("/") ? [] : linkParentParts;
   return [...base, ...target.split("/")];
@@ -213,7 +222,7 @@ function resolveWriteTarget(
         kind: "create",
         parentInode: direct.parentInode,
         leafName: direct.leafName,
-        canonicalPath: targetCanonical,
+        canonicalPath: direct.canonicalPath,
       };
     }
     if (options.exclusive) {
@@ -662,7 +671,7 @@ export function createFileSync(
       rev,
     );
     if (row === undefined) throw createWorkspaceError("EIO", "failed to allocate inode");
-    insertFileDirent(db, target.parentInode, target.leafName, row.inode, canonical);
+    insertFileDirent(db, target.parentInode, target.leafName, row.inode, target.canonicalPath);
   });
 }
 
@@ -807,6 +816,7 @@ function commitPendingBuffer(db: Database, entry: WriteBufferEntry, now: () => n
   let realInode = 0;
   try {
     db.transactionSync(() => {
+      const targetPath = childPath(db, parentInode, leafName, canonicalPath);
       // Re-check at commit time: a non-buffered writeFile or another
       // out-of-band path could have landed between open and release.
       const collision = db.one<{ child_inode: number }>(
@@ -832,7 +842,7 @@ function commitPendingBuffer(db: Database, entry: WriteBufferEntry, now: () => n
       if (row === undefined) {
         throw createWorkspaceError("EIO", "failed to allocate inode");
       }
-      insertFileDirent(db, parentInode, leafName, row.inode, canonicalPath);
+      insertFileDirent(db, parentInode, leafName, row.inode, targetPath);
       if (entry.size > 0) {
         const inode = row.inode;
         const chunkCount = Math.ceil(entry.size / CHUNK_SIZE);

--- a/packages/dofs/src/fs/writeFile.ts
+++ b/packages/dofs/src/fs/writeFile.ts
@@ -92,7 +92,7 @@ function resolveParent(
       countSymlinkFollow(follows, canonical);
       const target = node.link_target ?? "";
       const targetParts = symlinkTargetParts(target, realParts);
-      assertNotReadOnly(db, canonicalizePath(pathFromParts(targetParts)).path);
+      assertNotReadOnly(db, clampedPathFromParts(targetParts));
       if (target.startsWith("/")) {
         inodeStack.splice(1);
         realParts.splice(0);
@@ -169,6 +169,19 @@ function countSymlinkFollow(follows: SymlinkFollowState, path: string): void {
 
 function pathFromParts(parts: string[]): string {
   return `/${parts.join("/")}`;
+}
+
+function clampedPathFromParts(parts: string[]): string {
+  const clamped: string[] = [];
+  for (const part of parts) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      clamped.pop();
+      continue;
+    }
+    clamped.push(part);
+  }
+  return pathFromParts(clamped);
 }
 
 function childPath(db: Database, parentInode: number, leafName: string, path: string): string {
@@ -261,7 +274,7 @@ function resolveWriteTarget(
     countSymlinkFollow(follows, canonical);
     const realLinkParts = canonicalizePath(direct.canonicalPath).parts;
     targetParts = symlinkTargetParts(node.link_target ?? "", realLinkParts.slice(0, -1));
-    targetCanonical = canonicalizePath(pathFromParts(targetParts)).path;
+    targetCanonical = clampedPathFromParts(targetParts);
     assertNotReadOnly(db, targetCanonical);
     const finalPart = targetParts.at(-1);
     if (finalPart === undefined || finalPart === "" || finalPart === "." || finalPart === "..") {

--- a/packages/dofs/src/fs/writeRange.test.ts
+++ b/packages/dofs/src/fs/writeRange.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { Database } from "../storage.js";
 import { link } from "./link.js";
+import { mkdir } from "./mkdir.js";
 import { readFile } from "./readFile.js";
 import { resolveInode } from "./resolve.js";
+import { symlink } from "./symlink.js";
 import { withDB } from "./with-db.js";
 import {
   CHUNK_SIZE,
@@ -70,6 +72,18 @@ describe("direct range writes", () => {
       expect(node?.type).toBe("file");
       expect(node?.mode).toBe(0o600);
       expect(chunkRows(db, "/empty.txt")).toEqual([]);
+    });
+  });
+
+  it("invalidates a cached miss when creating through a symlinked parent", async () => {
+    await withDB((db) => {
+      mkdir(db, "/real", {}, () => 1000);
+      symlink(db, "/real", "/linkdir", () => 1000);
+      expect(resolveInode(db, "/real/file.txt")).toBeNull();
+
+      createFileSync(db, "/linkdir/file.txt", {}, () => 1001);
+
+      expect(resolveInode(db, "/real/file.txt")?.type).toBe("file");
     });
   });
 

--- a/packages/dofs/src/provider.test.ts
+++ b/packages/dofs/src/provider.test.ts
@@ -723,6 +723,22 @@ describe("SQLiteWorkspaceProvider — pending-create flush on rename/link/unlink
     });
   });
 
+  it("renameSync commits pending descendants created through another directory alias", async () => {
+    await withProvider((p) => {
+      p.mkdirSync("/real/src", { recursive: true });
+      p.mkdirSync("/outside");
+      p.symlinkSync("/real", "/alias");
+      p.symlinkSync("/outside", "/real/src/link");
+      p.openWriteBufferForCreateSync("/real/src/link/pending.txt", { mode: 0o644 });
+      p.writeRangeSync("/real/src/link/pending.txt", Buffer.from("pending"), 0);
+
+      p.renameSync("/alias/src", "/new");
+
+      expect((p.readFileSync("/new/link/pending.txt") as Buffer).toString()).toBe("pending");
+      expect(() => p.releaseWriteBufferSync("/new/link/pending.txt")).not.toThrow();
+    });
+  });
+
   it("rmdirSync preserves pending descendants", async () => {
     await withProvider((p) => {
       p.mkdirSync("/dir");

--- a/packages/dofs/src/provider.test.ts
+++ b/packages/dofs/src/provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { invalidateReadOnlyMountCache } from "./fs/mount-guard.js";
 import { withDB } from "./fs/with-db.js";
 import { SQLiteWorkspaceProvider } from "./provider.js";
 import type { Database } from "./storage.js";
@@ -736,6 +737,27 @@ describe("SQLiteWorkspaceProvider — pending-create flush on rename/link/unlink
 
       expect((p.readFileSync("/new/link/pending.txt") as Buffer).toString()).toBe("pending");
       expect(() => p.releaseWriteBufferSync("/new/link/pending.txt")).not.toThrow();
+    });
+  });
+
+  it("does not flush an unrelated uncommittable pending create", async () => {
+    await withProviderAndDB((p, db) => {
+      p.mkdirSync("/a");
+      p.mkdirSync("/b");
+      p.openWriteBufferForCreateSync("/a/pending.txt", { mode: 0o644 });
+      p.writeRangeSync("/a/pending.txt", Buffer.from("pending"), 0);
+      db.run(
+        "INSERT INTO _vfs_mounts (root, kind, indexed, mode) VALUES (?, ?, 1, ?)",
+        "/a",
+        "test",
+        "read-only",
+      );
+      invalidateReadOnlyMountCache(db);
+
+      expect(() => p.renameSync("/b", "/c")).not.toThrow();
+      expect(p.existsSync("/b")).toBe(false);
+      expect(p.existsSync("/c")).toBe(true);
+      expect((p.readFileSync("/a/pending.txt") as Buffer).toString()).toBe("pending");
     });
   });
 

--- a/packages/dofs/src/provider.test.ts
+++ b/packages/dofs/src/provider.test.ts
@@ -708,6 +708,21 @@ describe("SQLiteWorkspaceProvider — pending-create flush on rename/link/unlink
     });
   });
 
+  it("renameSync commits lexical pending descendants reached through symlinks", async () => {
+    await withProvider((p) => {
+      p.mkdirSync("/src");
+      p.mkdirSync("/outside");
+      p.symlinkSync("/outside", "/src/link");
+      p.openWriteBufferForCreateSync("/src/link/pending.txt", { mode: 0o644 });
+      p.writeRangeSync("/src/link/pending.txt", Buffer.from("pending"), 0);
+
+      p.renameSync("/src", "/new");
+
+      expect((p.readFileSync("/new/link/pending.txt") as Buffer).toString()).toBe("pending");
+      expect(() => p.releaseWriteBufferSync("/new/link/pending.txt")).not.toThrow();
+    });
+  });
+
   it("rmdirSync preserves pending descendants", async () => {
     await withProvider((p) => {
       p.mkdirSync("/dir");

--- a/packages/dofs/src/provider.test.ts
+++ b/packages/dofs/src/provider.test.ts
@@ -740,6 +740,21 @@ describe("SQLiteWorkspaceProvider — pending-create flush on rename/link/unlink
     });
   });
 
+  it("renameSync finds a pending file through another parent alias", async () => {
+    await withProvider((p) => {
+      p.mkdirSync("/real");
+      p.symlinkSync("/real", "/a");
+      p.symlinkSync("/real", "/b");
+      p.openWriteBufferForCreateSync("/a/pending.txt", { mode: 0o644 });
+      p.writeRangeSync("/a/pending.txt", Buffer.from("pending"), 0);
+
+      p.renameSync("/b/pending.txt", "/moved.txt");
+
+      expect((p.readFileSync("/moved.txt") as Buffer).toString()).toBe("pending");
+      expect(() => p.releaseWriteBufferSync("/moved.txt")).not.toThrow();
+    });
+  });
+
   it("renameSync commits pending files reached through the renamed symlink", async () => {
     await withProvider((p) => {
       p.mkdirSync("/one");

--- a/packages/dofs/src/provider.test.ts
+++ b/packages/dofs/src/provider.test.ts
@@ -740,6 +740,37 @@ describe("SQLiteWorkspaceProvider — pending-create flush on rename/link/unlink
     });
   });
 
+  it("renameSync commits pending files reached through the renamed symlink", async () => {
+    await withProvider((p) => {
+      p.mkdirSync("/one");
+      p.symlinkSync("/one", "/link");
+      p.openWriteBufferForCreateSync("/link/pending.txt", { mode: 0o644 });
+      p.writeRangeSync("/link/pending.txt", Buffer.from("pending"), 0);
+
+      p.renameSync("/link", "/newlink");
+
+      expect((p.readFileSync("/newlink/pending.txt") as Buffer).toString()).toBe("pending");
+      expect(() => p.releaseWriteBufferSync("/newlink/pending.txt")).not.toThrow();
+    });
+  });
+
+  it("unlinkSync commits pending files before a traversed symlink is replaced", async () => {
+    await withProvider((p) => {
+      p.mkdirSync("/one");
+      p.mkdirSync("/two");
+      p.symlinkSync("/one", "/link");
+      p.openWriteBufferForCreateSync("/link/pending.txt", { mode: 0o644 });
+      p.writeRangeSync("/link/pending.txt", Buffer.from("pending"), 0);
+
+      p.unlinkSync("/link");
+      p.symlinkSync("/two", "/link");
+
+      expect((p.readFileSync("/one/pending.txt") as Buffer).toString()).toBe("pending");
+      expect(p.existsSync("/two/pending.txt")).toBe(false);
+      expect(() => p.releaseWriteBufferSync("/one/pending.txt")).not.toThrow();
+    });
+  });
+
   it("does not flush an unrelated uncommittable pending create", async () => {
     await withProviderAndDB((p, db) => {
       p.mkdirSync("/a");

--- a/packages/dofs/src/provider.test.ts
+++ b/packages/dofs/src/provider.test.ts
@@ -692,6 +692,36 @@ describe("SQLiteWorkspaceProvider — pending-create flush on rename/link/unlink
     });
   });
 
+  it("renameSync commits pending descendants before moving a directory", async () => {
+    await withProvider((p) => {
+      p.mkdirSync("/old");
+      p.openWriteBufferForCreateSync("/old/pending.txt", { mode: 0o644 });
+      p.writeRangeSync("/old/pending.txt", Buffer.from("pending"), 0);
+
+      p.renameSync("/old", "/new");
+
+      expect((p.readFileSync("/new/pending.txt") as Buffer).toString()).toBe("pending");
+      expect(() =>
+        p.openWriteBufferForCreateSync("/new/pending.txt", { mode: 0o644 }),
+      ).toThrowError(expect.objectContaining({ code: "EEXIST" }));
+      expect(() => p.releaseWriteBufferSync("/new/pending.txt")).not.toThrow();
+    });
+  });
+
+  it("rmdirSync preserves pending descendants", async () => {
+    await withProvider((p) => {
+      p.mkdirSync("/dir");
+      p.openWriteBufferForCreateSync("/dir/pending.txt", { mode: 0o644 });
+      p.writeRangeSync("/dir/pending.txt", Buffer.from("pending"), 0);
+
+      expect(() => p.rmdirSync("/dir")).toThrowError(
+        expect.objectContaining({ code: "ENOTEMPTY" }),
+      );
+      expect((p.readFileSync("/dir/pending.txt") as Buffer).toString()).toBe("pending");
+      expect(() => p.releaseWriteBufferSync("/dir/pending.txt")).not.toThrow();
+    });
+  });
+
   it("unlinkSync commits then removes a pending-create file", async () => {
     await withProvider((p) => {
       p.openWriteBufferForCreateSync("/gone.txt", { mode: 0o644 });

--- a/packages/dofs/src/provider.ts
+++ b/packages/dofs/src/provider.ts
@@ -35,7 +35,7 @@ import {
 import {
   createFileSync as createFileSyncImpl,
   flushPendingByPath,
-  flushPendingUnderDirectory,
+  flushPendingUnderNode,
   openWriteBufferForCreateSync as openWriteBufferForCreateSyncImpl,
   openWriteBufferSync as openWriteBufferSyncImpl,
   releaseWriteBufferSync as releaseWriteBufferSyncImpl,
@@ -264,7 +264,7 @@ export class SQLiteWorkspaceProvider {
   }
 
   rmdirSync(path: string): void {
-    flushPendingUnderDirectory(this.db, path, this.now);
+    flushPendingUnderNode(this.db, path, this.now);
     rmImpl(this.db, path, {});
   }
 
@@ -279,6 +279,7 @@ export class SQLiteWorkspaceProvider {
     // resulting GC sees the orphaned blob, matching the non-buffered
     // shape). The buffer's open handles continue to address bytes
     // through the inode-keyed cache.
+    flushPendingUnderNode(this.db, path, this.now);
     flushPendingByPath(this.db, path, this.now);
     // Capture the target inode before rm runs so we can evict its
     // write-buffer cache entry if rm removed the last link. Without
@@ -325,8 +326,8 @@ export class SQLiteWorkspaceProvider {
     // touches dirents: the source needs a real inode to move, and a
     // pending buffer at the destination would otherwise slip past
     // rename's dirent-based existence check and lose bytes on release.
-    flushPendingUnderDirectory(this.db, oldPath, this.now);
-    flushPendingUnderDirectory(this.db, newPath, this.now);
+    flushPendingUnderNode(this.db, oldPath, this.now);
+    flushPendingUnderNode(this.db, newPath, this.now);
     flushPendingByPath(this.db, oldPath, this.now);
     flushPendingByPath(this.db, newPath, this.now);
     // Capture the destination inode before the rename so we can evict

--- a/packages/dofs/src/provider.ts
+++ b/packages/dofs/src/provider.ts
@@ -35,6 +35,7 @@ import {
 import {
   createFileSync as createFileSyncImpl,
   flushPendingByPath,
+  flushPendingUnderDirectory,
   openWriteBufferForCreateSync as openWriteBufferForCreateSyncImpl,
   openWriteBufferSync as openWriteBufferSyncImpl,
   releaseWriteBufferSync as releaseWriteBufferSyncImpl,
@@ -263,6 +264,7 @@ export class SQLiteWorkspaceProvider {
   }
 
   rmdirSync(path: string): void {
+    flushPendingUnderDirectory(this.db, path, this.now);
     rmImpl(this.db, path, {});
   }
 
@@ -323,6 +325,8 @@ export class SQLiteWorkspaceProvider {
     // touches dirents: the source needs a real inode to move, and a
     // pending buffer at the destination would otherwise slip past
     // rename's dirent-based existence check and lose bytes on release.
+    flushPendingUnderDirectory(this.db, oldPath, this.now);
+    flushPendingUnderDirectory(this.db, newPath, this.now);
     flushPendingByPath(this.db, oldPath, this.now);
     flushPendingByPath(this.db, newPath, this.now);
     // Capture the destination inode before the rename so we can evict

--- a/packages/dofs/src/provider.ts
+++ b/packages/dofs/src/provider.ts
@@ -12,6 +12,7 @@ import { getBlobBytes } from "./fs/blobCache.js";
 import { link as linkImpl } from "./fs/link.js";
 import type { MkdirOptions } from "./fs/mkdir.js";
 import { mkdir as mkdirImpl } from "./fs/mkdir.js";
+import { findPendingWriteBuffer } from "./fs/pendingWriteBuffer.js";
 import { readdir as readdirImpl } from "./fs/readdir.js";
 import { readRangeSync as readRangeSyncImpl } from "./fs/readFile.js";
 import { readlink as readlinkImpl } from "./fs/readlink.js";
@@ -27,11 +28,7 @@ import {
   type WatchHandle,
   type WatchOptions,
 } from "./fs/watch.js";
-import {
-  deleteWriteBuffer,
-  getPendingWriteBufferByPath,
-  getWriteBuffer,
-} from "./fs/writeBuffer.js";
+import { deleteWriteBuffer, getWriteBuffer } from "./fs/writeBuffer.js";
 import {
   createFileSync as createFileSyncImpl,
   flushPendingByPath,
@@ -198,8 +195,7 @@ export class SQLiteWorkspaceProvider {
   }
 
   lstatSync(path: string, _options?: { bigint?: boolean }): VirtualStatsLike {
-    const { path: canonical } = canonicalizePath(path);
-    const pending = getPendingWriteBufferByPath(this.db, canonical);
+    const pending = findPendingWriteBuffer(this.db, path);
     if (pending !== undefined && pending.pending !== undefined) {
       return wrapStats({
         mode: pending.mode & 0o7777,
@@ -361,8 +357,7 @@ export class SQLiteWorkspaceProvider {
     options?: BufferEncoding | { encoding?: BufferEncoding | null } | null,
   ): Buffer | string {
     const encoding = typeof options === "string" ? options : options?.encoding;
-    const { path: canonical } = canonicalizePath(path);
-    const pending = getPendingWriteBufferByPath(this.db, canonical);
+    const pending = findPendingWriteBuffer(this.db, path);
     if (pending !== undefined) {
       const snapshot = Buffer.alloc(pending.size);
       snapshot.set(pending.buf.subarray(0, pending.size));
@@ -473,8 +468,7 @@ export class SQLiteWorkspaceProvider {
   }
 
   chmodSync(path: string, mode: number): void {
-    const { path: canonical } = canonicalizePath(path);
-    const pending = getPendingWriteBufferByPath(this.db, canonical);
+    const pending = findPendingWriteBuffer(this.db, path);
     if (pending !== undefined) {
       // Pending-create files don't have a row yet; stash the mode on
       // the buffer so the eventual INSERT picks it up.
@@ -516,8 +510,7 @@ export class SQLiteWorkspaceProvider {
 
   existsSync(path: string): boolean {
     try {
-      const { path: canonical } = canonicalizePath(path);
-      if (getPendingWriteBufferByPath(this.db, canonical) !== undefined) return true;
+      if (findPendingWriteBuffer(this.db, path) !== undefined) return true;
       return resolveInode(this.db, path) !== null;
     } catch {
       return false;


### PR DESCRIPTION

`@cloudflare/dofs` had three symlink gaps that made writes behave differently from reads. Relative symlink targets such as `target.txt` failed during resolution because they were treated as invalid absolute paths. Writes through a symlinked parent directory failed with `ENOTDIR`, even though reads through the same path worked. Writes to a final symlink wrote chunks onto the symlink node instead of the target file, which left the target unchanged and broke the invariant that symlink nodes do not own file chunks.

This change makes symlink handling consistent across resolution and writes. Relative symlink targets now resolve from the directory that contains the symlink. Write parent resolution now uses the normal resolver, so symlinked directories work the same way for reads and writes. Final symlinks are followed for normal writes, while exclusive writes still fail on the existing symlink with `EEXIST`. If a final symlink points at a missing file, the write creates that target, including relative targets resolved from the symlink parent. The write path also checks read-only mounts for both the original path and the resolved target path.

A quick manual check is to create a symlink and write through it:

```ts
await writeFile(db, "/target", "old", {}, () => 0);
symlink(db, "/target", "/link", () => 0);
await writeFile(db, "/link", "new", {}, () => 0);
expect(await readFile(db, "/target", "utf8")).toBe("new");
```

The test coverage includes relative symlink resolution, dangling relative targets, writes through symlinked directories, final symlink writes, dangling final symlink creation, exclusive writes, range writes, and checks that symlink nodes do not receive file chunks.

Fixes #54. Fixes #90. Fixes #65. Fixes #55.
