### PR TITLE
Add celld example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ packages/computer/dist/bin/computerd-*
 # from the example directory; they must never be committed.
 .dev.vars
 **/.dev.vars
+
+# Local celld example state.
+examples/celld/.celld-s3*/
+examples/celld/.celld-state*/

--- a/examples/celld/README.md
+++ b/examples/celld/README.md
@@ -11,8 +11,10 @@ small local S3-compatible shim so the prototype can run without AWS S3 or
 Cloudflare R2.
 
 It also wires celld's experimental Worker Loader into a small
-`celld-javascript` Computer runtime backend. That backend supports simple
-ECMAScript-module execution with JSON input/output. It does **not** yet expose
+`celld-javascript` Computer runtime backend in
+`src/celld-javascript-backend.ts`. That backend supports ECMAScript-module
+execution with JSON input/output, captured console output, and a second `ctx`
+argument containing `env`, `cwd`, and `stdin`. It does **not** yet expose
 Computer's full `WorkerJavaScriptBackend` filesystem/capability bridge; see
 [JavaScript environment gaps](#javascript-environment-gaps).
 
@@ -115,7 +117,7 @@ Start celld with `CELLD_WORKER_LOADER=LOADER` and call `/exec`:
 ```sh
 curl -X POST 'http://127.0.0.1:8080/exec?cell=demo' \
   -H 'content-type: application/json' \
-  -d '{"source":"console.log(\"running\"); export default (input) => ({ doubled: input.n * 2 })","input":{"n":21}}'
+  -d '{"source":"console.log(\"running\"); export default (input, ctx) => ({ doubled: input.n * 2, cwd: ctx.cwd, name: ctx.env.NAME })","input":{"n":21},"env":{"NAME":"celld"}}'
 ```
 
 Expected shape:
@@ -127,6 +129,36 @@ Expected shape:
   "value": { "doubled": 42 }
 }
 ```
+
+User modules can either default-export a value or a function. If the default
+export is a function, it is called as `default(input, ctx)`. The current `ctx`
+shape is:
+
+```ts
+interface CelldExecContext {
+  env: Record<string, string>;
+  cwd: string;
+  stdin: string;
+  fs: {
+    readFile(): never;
+    writeFile(): never;
+    readdir(): never;
+    mkdir(): never;
+    rm(): never;
+    stat(): never;
+    exists(): never;
+    ls(): never;
+    find(): never;
+    grep(): never;
+  };
+}
+```
+
+`ctx.fs` is present but intentionally throws a descriptive error today. I tried
+passing a host filesystem `RpcTarget` into the loaded worker as a second step;
+celld v0.1.0 rejected that capability argument with the same structured-clone
+failure as the full Computer bridge. The outer HTTP `/fs` routes are the working
+filesystem API for now.
 
 The backend intentionally uses static imports in the generated runner because
 celld v0.1.0 does not support dynamic `import("entry.js")` in loaded workers.
@@ -163,13 +195,15 @@ working yet.
 The celld Worker Loader works for simple JavaScript execution, but these gaps
 remain before Computer's full `WorkerJavaScriptBackend` can be used unchanged:
 
-- **Cross-isolate `RpcTarget` bridge cloning**: passing Computer's
+- **Cross-isolate capability bridge cloning**: passing Computer's
   `WorkspaceRuntimeBridge` into the loaded worker failed with
-  `() => {} could not be cloned`. The prototype avoids that by returning a
-  plain JSON result instead of passing host capability stubs.
+  `() => {} could not be cloned`. Passing a smaller filesystem-only `RpcTarget`
+  as a `ctx.fs` capability failed the same way. The example avoids that by
+  returning a plain JSON result instead of passing host capability stubs.
 - **Filesystem bridge**: because the bridge cannot be passed yet, loaded code
-  cannot import Computer's durable `node:fs/promises` shim. celld's native
-  `node:fs` compatibility is intentionally partial and reads return `ENOENT`.
+  cannot import Computer's durable `node:fs/promises` shim and `ctx.fs` is only
+  a throwing placeholder. celld's native `node:fs` compatibility is
+  intentionally partial and reads return `ENOENT`.
 - **Stream transfer for live stdout/stderr**: Computer's backend streams framed
   output through a `ReadableStream` passed back to the host. This prototype
   buffers `stdout`/`stderr` and returns them when execution completes.
@@ -197,8 +231,9 @@ layout is `.celld-s3/<bucket>/<key>`.
 
 ```
 examples/celld/
-  src/index.ts                Worker + DO + HTTP filesystem + JS backend routes
-  script/local-s3-shim.mjs    tiny filesystem-backed S3-compatible endpoint
-  script/local-dev.mjs        start shim, deploy, and run celld locally
-  wrangler.jsonc              celld-supported Wrangler config subset
+  src/index.ts                    Worker + DO + HTTP filesystem routes
+  src/celld-javascript-backend.ts celld Worker Loader module backend
+  script/local-s3-shim.mjs        tiny filesystem-backed S3-compatible endpoint
+  script/local-dev.mjs            start shim, deploy, and run celld locally
+  wrangler.jsonc                  celld-supported Wrangler config subset
 ```

--- a/examples/celld/README.md
+++ b/examples/celld/README.md
@@ -190,29 +190,103 @@ celld restore failed for FilesystemAgent:...: open managed db .../db.sqlite: dat
 So the Agents SDK wiring is present for iteration, but not counted as validated
 working yet.
 
-## JavaScript environment gaps
+## Known gaps and follow-ups
 
-The celld Worker Loader works for simple JavaScript execution, but these gaps
-remain before Computer's full `WorkerJavaScriptBackend` can be used unchanged:
+The celld Worker Loader works for simple JavaScript execution, but there are a
+few concrete gaps before this example can use Computer's full
+`WorkerJavaScriptBackend` unchanged.
 
-- **Cross-isolate capability bridge cloning**: passing Computer's
-  `WorkspaceRuntimeBridge` into the loaded worker failed with
-  `() => {} could not be cloned`. Passing a smaller filesystem-only `RpcTarget`
-  as a `ctx.fs` capability failed the same way. The example avoids that by
-  returning a plain JSON result instead of passing host capability stubs.
-- **Filesystem bridge**: because the bridge cannot be passed yet, loaded code
-  cannot import Computer's durable `node:fs/promises` shim and `ctx.fs` is only
-  a throwing placeholder. celld's native `node:fs` compatibility is
-  intentionally partial and reads return `ENOENT`.
-- **Stream transfer for live stdout/stderr**: Computer's backend streams framed
-  output through a `ReadableStream` passed back to the host. This prototype
-  buffers `stdout`/`stderr` and returns them when execution completes.
-- **Dynamic imports**: celld v0.1.0 rejected `import("entry.js")` inside a
-  loaded worker. The runner statically imports the generated entry module.
-- **Loaded-worker shape**: celld expects a default Worker with a `fetch`
-  function even when using a named RPC entrypoint, so the runner includes both.
-- **Agent runtime**: the Agents SDK bundles/deploys, but the live Agent request
-  hit the celld managed-DB lock noted above.
+### 1. Host capability stubs cannot cross into the loaded worker yet
+
+Computer's full backend passes a `WorkspaceRuntimeBridge` capability object into
+the Dynamic Worker so user code can call back into the host Durable Object for
+filesystem, module resolution, stdout/stderr events, and other runtime services.
+Under celld v0.1.0, that argument failed during the loaded-worker RPC call:
+
+```text
+DataCloneError: () => {} could not be cloned
+```
+
+I also tried a smaller filesystem-only `RpcTarget` intended to back `ctx.fs`;
+it failed with the same clone error. For now, `CelldJavaScriptBackend` only
+passes plain structured-clone data (`input`, `env`, `cwd`, `stdin`) and returns
+a plain JSON result plus buffered output.
+
+Follow-up: celld's Worker Loader RPC needs to support passing capability stubs
+(or a documented equivalent) as named-Entrypoint arguments between the host
+Worker and a loaded Worker.
+
+### 2. No durable filesystem inside loaded JavaScript yet
+
+Because the host bridge cannot be passed, loaded code cannot import Computer's
+durable `node:fs/promises` shim. The `ctx.fs` object is present to reserve the
+intended API shape, but every method currently throws a descriptive error.
+celld's native `node:fs` compatibility is not a replacement: it is intentionally
+partial and reads return `ENOENT`.
+
+Working filesystem access today is the outer HTTP API:
+
+```text
+PUT    /fs/workspace/<path>
+GET    /fs/workspace/<path>
+DELETE /fs/workspace/<path>
+GET    /ls/workspace/<dir>
+POST   /mkdir/workspace/<dir>
+```
+
+Follow-up: once capability stubs can cross into loaded workers, wire `ctx.fs`
+first. After that, evaluate whether Computer's existing durable
+`node:fs/promises` module bridge can be reused unchanged.
+
+### 3. Output is buffered, not streamed live
+
+Computer's full backend streams runtime events as they happen. This example
+captures `console.log/info` as stdout and `console.warn/error` as stderr inside
+the loaded Worker, then returns those buffers when the function completes.
+
+Follow-up: support returning/transferring a stream or event capability from the
+loaded Worker so `/exec` can expose live stdout/stderr and long-running task
+status.
+
+### 4. Loaded-worker module loading differs from Workerd
+
+Two celld Worker Loader differences are handled in the example runner:
+
+- Dynamic `import("entry.js")` failed under celld v0.1.0, so the runner uses a
+  static `import * as userModule from "entry.js"`.
+- The loaded Worker needed a default `fetch` export even though execution uses a
+  named `WorkerEntrypoint`, so the runner exports both `Runner` and a tiny
+  default `fetch()` handler.
+
+Follow-up: decide whether these are intended celld constraints or compatibility
+bugs. If they are fixed, the generated runner can become closer to Computer's
+normal Worker JavaScript backend.
+
+### 5. Agents SDK is bundled but not validated at runtime
+
+`FilesystemAgent` bundles and deploys with celld once the `path` npm polyfill is
+present, but a live Agent request hit a celld managed-SQLite restore failure:
+
+```text
+celld restore failed for FilesystemAgent:...: open managed db .../db.sqlite: database is locked
+```
+
+Follow-up: investigate celld's managed SQLite locking/restore path with Agents
+SDK Durable Objects. The basic Worker and `CelldWorkspace` Durable Object paths
+are validated; the Agent Durable Object is not yet counted as working.
+
+### Current validation matrix
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Local S3 shim | Working | Supports the S3 subset celld uses for local deploy/run. |
+| HTTP filesystem API | Working | Validated against actual celld with the local S3 shim. |
+| `/exec` simple JavaScript | Working | Uses celld Worker Loader + named `WorkerEntrypoint`. |
+| `default(input, ctx)` | Working | `ctx.env`, `ctx.cwd`, and `ctx.stdin` are available. |
+| `ctx.fs` in loaded JavaScript | Gap | Placeholder only; host capability passing fails to clone. |
+| Computer `WorkerJavaScriptBackend` unchanged | Gap | Blocked on host bridge/capability passing. |
+| Live stdout/stderr streaming | Gap | Output is buffered until completion. |
+| Agents SDK route | Gap | Bundles/deploys, but live request hit SQLite lock. |
 
 ## Local S3 shim
 

--- a/examples/celld/README.md
+++ b/examples/celld/README.md
@@ -1,0 +1,126 @@
+# celld example
+
+> [!IMPORTANT]
+> Prototype only. This is a small integration sketch for running a
+> `@cloudflare/computer` Workspace inside a Worker deployed to
+> [`denoland/celld`](https://github.com/denoland/celld).
+
+This example uses celld as the Durable Object runtime and
+`@cloudflare/computer` as the durable Workspace/filesystem layer. It includes a
+small local S3-compatible shim so the prototype can run without AWS S3 or
+Cloudflare R2.
+
+There are intentionally **no Computer runtime backends** in this example. celld
+has an experimental Dynamic Worker loader, but the current celld RPC/clone
+surface is not enough for Computer's `WorkerJavaScriptBackend` bridge. This
+prototype focuses on the filesystem API.
+
+## Architecture
+
+```
+client ─► celld HTTP (:8080)
+             │
+             ▼
+       Worker fetch handler
+             │ direct DO RPC methods
+             ▼
+       CelldWorkspace Durable Object
+             │
+             ▼
+       @cloudflare/computer Workspace filesystem (DO SQLite)
+
+celld deployment/state/leases ─► local S3 shim (:9000) ─► .celld-s3/
+```
+
+The Worker calls explicit methods on the Durable Object (`writeFile`,
+`readFile`, `readdir`, `mkdir`, `rm`) rather than using Computer's nested
+`WorkspaceStub` from outside the object. That keeps the public surface within
+celld's currently supported JS RPC shape.
+
+## Run locally
+
+Prerequisites:
+
+- Node.js
+- `celld` on your `PATH` (`curl -fsSL https://celld.dev/install.sh | sh`)
+- dependencies installed from the repository root (`npm install`)
+
+One-command local run:
+
+```sh
+npm run dev:local --workspace @example/computer-celld
+```
+
+That command starts `script/local-s3-shim.mjs`, runs `celld deploy`, then
+starts `celld` on `127.0.0.1:8080`.
+
+If you prefer separate terminals:
+
+```sh
+# terminal 1
+npm run shim --workspace @example/computer-celld
+
+# terminal 2
+npm run deploy:local --workspace @example/computer-celld
+npm run celld:local --workspace @example/computer-celld
+```
+
+## HTTP filesystem surface
+
+All paths are absolute Workspace paths with the leading slash represented in
+the URL. The handler rejects anything outside `/workspace`. A `cell` query
+parameter selects the Durable Object name; it defaults to `default`.
+
+```sh
+# Help
+curl http://127.0.0.1:8080/
+
+# Write a file
+echo 'hello from celld + computer' | curl -X PUT --data-binary @- \
+  'http://127.0.0.1:8080/fs/workspace/hello.txt?cell=demo'
+
+# Read the file back
+curl 'http://127.0.0.1:8080/fs/workspace/hello.txt?cell=demo'
+
+# List a directory
+curl 'http://127.0.0.1:8080/ls/workspace?cell=demo'
+
+# Create a directory
+curl -X POST 'http://127.0.0.1:8080/mkdir/workspace/tmp?cell=demo'
+
+# Delete a file
+curl -X DELETE 'http://127.0.0.1:8080/fs/workspace/hello.txt?cell=demo'
+```
+
+Routes:
+
+```
+PUT    /fs/workspace/<path>          raw request body -> /workspace/<path>
+GET    /fs/workspace/<path>          read /workspace/<path>
+DELETE /fs/workspace/<path>          delete a file; add ?recursive=1 for dirs
+GET    /ls/workspace/<dir>           JSON directory listing
+POST   /mkdir/workspace/<dir>        mkdir -p
+```
+
+## Local S3 shim
+
+`script/local-s3-shim.mjs` implements the small path-style S3 subset celld uses
+for local development:
+
+- `PUT`, `GET`, `HEAD`, `DELETE` object requests
+- `GET ?list-type=2&prefix=...` listings
+- `If-Match` / `If-None-Match: *` conditional writes
+- `ETag` and `x-amz-meta-*` headers
+
+It is intentionally a development shim, not a complete S3 server. The on-disk
+layout is `.celld-s3/<bucket>/<key>`.
+
+## Layout
+
+```
+examples/celld/
+  src/index.ts                Worker + Durable Object + HTTP filesystem routes
+  script/local-s3-shim.mjs    tiny filesystem-backed S3-compatible endpoint
+  script/local-dev.mjs        start shim, deploy, and run celld locally
+  wrangler.jsonc              celld-supported Wrangler config subset
+```

--- a/examples/celld/README.md
+++ b/examples/celld/README.md
@@ -10,10 +10,11 @@ This example uses celld as the Durable Object runtime and
 small local S3-compatible shim so the prototype can run without AWS S3 or
 Cloudflare R2.
 
-There are intentionally **no Computer runtime backends** in this example. celld
-has an experimental Dynamic Worker loader, but the current celld RPC/clone
-surface is not enough for Computer's `WorkerJavaScriptBackend` bridge. This
-prototype focuses on the filesystem API.
+It also wires celld's experimental Worker Loader into a small
+`celld-javascript` Computer runtime backend. That backend supports simple
+ECMAScript-module execution with JSON input/output. It does **not** yet expose
+Computer's full `WorkerJavaScriptBackend` filesystem/capability bridge; see
+[JavaScript environment gaps](#javascript-environment-gaps).
 
 ## Architecture
 
@@ -26,16 +27,20 @@ client ─► celld HTTP (:8080)
              ▼
        CelldWorkspace Durable Object
              │
-             ▼
-       @cloudflare/computer Workspace filesystem (DO SQLite)
+             ├─ @cloudflare/computer Workspace filesystem (DO SQLite)
+             │
+             └─ celld-javascript backend
+                    │ env.LOADER.load(...)
+                    ▼
+                  celld Dynamic Worker
 
 celld deployment/state/leases ─► local S3 shim (:9000) ─► .celld-s3/
 ```
 
 The Worker calls explicit methods on the Durable Object (`writeFile`,
-`readFile`, `readdir`, `mkdir`, `rm`) rather than using Computer's nested
-`WorkspaceStub` from outside the object. That keeps the public surface within
-celld's currently supported JS RPC shape.
+`readFile`, `readdir`, `mkdir`, `rm`, `exec`) rather than using Computer's
+nested `WorkspaceStub` from outside the object. That keeps the public surface
+within celld's currently supported JS RPC shape.
 
 ## Run locally
 
@@ -52,7 +57,7 @@ npm run dev:local --workspace @example/computer-celld
 ```
 
 That command starts `script/local-s3-shim.mjs`, runs `celld deploy`, then
-starts `celld` on `127.0.0.1:8080`.
+starts `celld` on `127.0.0.1:8080` with `CELLD_WORKER_LOADER=LOADER`.
 
 If you prefer separate terminals:
 
@@ -100,7 +105,80 @@ GET    /fs/workspace/<path>          read /workspace/<path>
 DELETE /fs/workspace/<path>          delete a file; add ?recursive=1 for dirs
 GET    /ls/workspace/<dir>           JSON directory listing
 POST   /mkdir/workspace/<dir>        mkdir -p
+POST   /exec                         JavaScript module execution via celld Worker Loader
 ```
+
+## JavaScript backend
+
+Start celld with `CELLD_WORKER_LOADER=LOADER` and call `/exec`:
+
+```sh
+curl -X POST 'http://127.0.0.1:8080/exec?cell=demo' \
+  -H 'content-type: application/json' \
+  -d '{"source":"console.log(\"running\"); export default (input) => ({ doubled: input.n * 2 })","input":{"n":21}}'
+```
+
+Expected shape:
+
+```json
+{
+  "status": "completed",
+  "exitCode": 0,
+  "value": { "doubled": 42 }
+}
+```
+
+The backend intentionally uses static imports in the generated runner because
+celld v0.1.0 does not support dynamic `import("entry.js")` in loaded workers.
+Loaded workers also need a default `fetch` export, so the runner includes a tiny
+`fetch() { return new Response("ok") }` handler and exposes the evaluator as a
+named `WorkerEntrypoint`.
+
+## Agents SDK attempt
+
+`FilesystemAgent` is included as a smoke-test attempt for the Cloudflare Agents
+SDK on celld. It constructs a filesystem-only Computer Workspace and calls
+`createAITools({ workspace, assets: false })`.
+
+Routes:
+
+```sh
+curl 'http://127.0.0.1:8080/agents/filesystem-agent/demo'
+curl 'http://127.0.0.1:8080/agents/filesystem-agent/demo/tools'
+```
+
+Status: the Worker bundles and deploys with celld once the `path` npm polyfill
+is present, but a live request currently failed during celld restore with a
+managed SQLite lock:
+
+```text
+celld restore failed for FilesystemAgent:...: open managed db .../db.sqlite: database is locked
+```
+
+So the Agents SDK wiring is present for iteration, but not counted as validated
+working yet.
+
+## JavaScript environment gaps
+
+The celld Worker Loader works for simple JavaScript execution, but these gaps
+remain before Computer's full `WorkerJavaScriptBackend` can be used unchanged:
+
+- **Cross-isolate `RpcTarget` bridge cloning**: passing Computer's
+  `WorkspaceRuntimeBridge` into the loaded worker failed with
+  `() => {} could not be cloned`. The prototype avoids that by returning a
+  plain JSON result instead of passing host capability stubs.
+- **Filesystem bridge**: because the bridge cannot be passed yet, loaded code
+  cannot import Computer's durable `node:fs/promises` shim. celld's native
+  `node:fs` compatibility is intentionally partial and reads return `ENOENT`.
+- **Stream transfer for live stdout/stderr**: Computer's backend streams framed
+  output through a `ReadableStream` passed back to the host. This prototype
+  buffers `stdout`/`stderr` and returns them when execution completes.
+- **Dynamic imports**: celld v0.1.0 rejected `import("entry.js")` inside a
+  loaded worker. The runner statically imports the generated entry module.
+- **Loaded-worker shape**: celld expects a default Worker with a `fetch`
+  function even when using a named RPC entrypoint, so the runner includes both.
+- **Agent runtime**: the Agents SDK bundles/deploys, but the live Agent request
+  hit the celld managed-DB lock noted above.
 
 ## Local S3 shim
 
@@ -119,7 +197,7 @@ layout is `.celld-s3/<bucket>/<key>`.
 
 ```
 examples/celld/
-  src/index.ts                Worker + Durable Object + HTTP filesystem routes
+  src/index.ts                Worker + DO + HTTP filesystem + JS backend routes
   script/local-s3-shim.mjs    tiny filesystem-backed S3-compatible endpoint
   script/local-dev.mjs        start shim, deploy, and run celld locally
   wrangler.jsonc              celld-supported Wrangler config subset

--- a/examples/celld/README.md
+++ b/examples/celld/README.md
@@ -146,9 +146,19 @@ The agent receives these tools from `@cloudflare/computer/tools`:
 
 ## JavaScript backend limits
 
-The celld Worker Loader can run ECMAScript modules with JSON input and output.
-The module's default export receives `(input, ctx)`, where `ctx` includes
-`env`, `cwd`, and `stdin`.
+The celld Worker Loader can run JavaScript modules with JSON input and output.
+The source passed to `exec` must be a complete module, not a filename or a bare
+script. It must have a default export. A default function receives `(input,
+ctx)`, where `ctx` includes `env`, `cwd`, and `stdin`:
+
+```js
+export default async function main(input, ctx) {
+  console.log("cwd:", ctx.cwd);
+  return { received: input };
+}
+```
+
+`ctx.cwd` is metadata; the directory is not mounted in the Dynamic Worker.
 
 The backend does not yet provide the full Computer
 `WorkerJavaScriptBackend` bridge:

--- a/examples/celld/README.md
+++ b/examples/celld/README.md
@@ -1,313 +1,182 @@
-# celld example
+# celld chat agent example
 
 > [!IMPORTANT]
-> Prototype only. This is a small integration sketch for running a
-> `@cloudflare/computer` Workspace inside a Worker deployed to
-> [`denoland/celld`](https://github.com/denoland/celld).
+> Prototype only. This example runs a `@cloudflare/computer` Workspace and an
+> Agents SDK chat agent on [`denoland/celld`](https://github.com/denoland/celld).
 
-This example uses celld as the Durable Object runtime and
-`@cloudflare/computer` as the durable Workspace/filesystem layer. It includes a
-small local S3-compatible shim so the prototype can run without AWS S3 or
-Cloudflare R2.
+The example has one durable object, `CelldAgent`. It owns the chat history and
+Workspace in the same SQLite database. The Worker exposes the standard Agents
+WebSocket route and no separate filesystem or execution HTTP API.
 
-It also wires celld's experimental Worker Loader into a small
-`celld-javascript` Computer runtime backend in
-`src/celld-javascript-backend.ts`. That backend supports ECMAScript-module
-execution with JSON input/output, captured console output, and a second `ctx`
-argument containing `env`, `cwd`, and `stdin`. It does **not** yet expose
-Computer's full `WorkerJavaScriptBackend` filesystem/capability bridge; see
-[JavaScript environment gaps](#javascript-environment-gaps).
+The terminal client uses the AI SDK TUI. Workspace operations are available to
+the model through `createAITools()`.
 
 ## Architecture
 
-```
-client ─► celld HTTP (:8080)
-             │
-             ▼
-       Worker fetch handler
-             │ direct DO RPC methods
-             ▼
-       CelldWorkspace Durable Object
-             │
-             ├─ @cloudflare/computer Workspace filesystem (DO SQLite)
-             │
-             └─ celld-javascript backend
-                    │ env.LOADER.load(...)
-                    ▼
-                  celld Dynamic Worker
-
-celld deployment/state/leases ─► local S3 shim (:9000) ─► .celld-s3/
+```text
+terminal (`npm run chat`)
+        │ AgentClient WebSocket
+        ▼
+/agents/celld-agent/<name>
+        │ routeAgentRequest
+        ▼
+CelldAgent (AIChatAgent + withWorkspace)
+        ├─ chat history in SQLite
+        ├─ @cloudflare/computer Workspace in the same SQLite database
+        │    └─ read, ls, find, grep, write, edit, and delete tools
+        ├─ celld-javascript runtime backend
+        │    └─ exec tool when env.LOADER is available
+        └─ Cloudflare Workers AI REST API
+             └─ account ID and API token from celld Worker vars
 ```
 
-The Worker calls explicit methods on the Durable Object (`writeFile`,
-`readFile`, `readdir`, `mkdir`, `rm`, `exec`) rather than using Computer's
-nested `WorkspaceStub` from outside the object. That keeps the public surface
-within celld's currently supported JS RPC shape.
+`CelldAgent.onChatMessage()` calls `getWorkspace(this)`, passes that Workspace
+to `createAITools()`, and gives the resulting tools to the AI SDK tool loop.
+There is no hand-written Durable Object RPC interface.
+
+## Install celld
+
+Install the current celld release and make sure `~/.local/bin` is on `PATH`:
+
+```sh
+curl -fsSL https://celld.dev/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+celld --version
+```
+
+`celld deploy` also needs `esbuild` on `PATH`. Installing this repository's npm
+dependencies provides it under `node_modules/.bin`.
+
+Build `@cloudflare/computer` before deploying the example because the workspace
+package resolves through its `dist` directory:
+
+```sh
+npm install
+npm run build --workspace @cloudflare/computer
+export PATH="$PWD/node_modules/.bin:$PATH"
+```
+
+## Configure Cloudflare credentials
+
+celld does not provide the managed Workers AI binding. The agent configures
+`workers-ai-provider` with an account ID and API token, which calls the
+Cloudflare Workers AI REST API directly.
+
+Create an API token with Workers AI read access, then set both values in your
+local environment:
+
+```sh
+export CLOUDFLARE_ACCOUNT_ID=<account-id>
+export CLOUDFLARE_API_TOKEN=<api-token>
+```
+
+`dev:local` forwards these values to celld as `CELLD_VAR_*` Worker variables.
+If you run the `celld` command yourself, set the prefixed names directly:
+
+```sh
+export CELLD_VAR_CLOUDFLARE_ACCOUNT_ID="$CLOUDFLARE_ACCOUNT_ID"
+export CELLD_VAR_CLOUDFLARE_API_TOKEN="$CLOUDFLARE_API_TOKEN"
+```
+
+Keep the API token in your local environment. Do not add it to
+`wrangler.jsonc` or another tracked file.
 
 ## Run locally
 
-Prerequisites:
-
-- Node.js
-- `celld` on your `PATH` (`curl -fsSL https://celld.dev/install.sh | sh`)
-- dependencies installed from the repository root (`npm install`)
-
-One-command local run:
+From the repository root, start celld in one terminal:
 
 ```sh
+export PATH="$PWD/node_modules/.bin:$HOME/.local/bin:$PATH"
+export CLOUDFLARE_ACCOUNT_ID=<account-id>
+export CLOUDFLARE_API_TOKEN=<api-token>
 npm run dev:local --workspace @example/computer-celld
 ```
 
-That command starts `script/local-s3-shim.mjs`, runs `celld deploy`, then
-starts `celld` on `127.0.0.1:8080` with `CELLD_WORKER_LOADER=LOADER`.
+`dev:local` starts the local S3-compatible shim, deploys the Worker, enables the
+celld Worker Loader as `env.LOADER`, and listens on
+`http://127.0.0.1:8080`.
 
-If you prefer separate terminals:
-
-```sh
-# terminal 1
-npm run shim --workspace @example/computer-celld
-
-# terminal 2
-npm run deploy:local --workspace @example/computer-celld
-npm run celld:local --workspace @example/computer-celld
-```
-
-## HTTP filesystem surface
-
-All paths are absolute Workspace paths with the leading slash represented in
-the URL. The handler rejects anything outside `/workspace`. A `cell` query
-parameter selects the Durable Object name; it defaults to `default`.
+Open the terminal chat in another terminal:
 
 ```sh
-# Help
-curl http://127.0.0.1:8080/
-
-# Write a file
-echo 'hello from celld + computer' | curl -X PUT --data-binary @- \
-  'http://127.0.0.1:8080/fs/workspace/hello.txt?cell=demo'
-
-# Read the file back
-curl 'http://127.0.0.1:8080/fs/workspace/hello.txt?cell=demo'
-
-# List a directory
-curl 'http://127.0.0.1:8080/ls/workspace?cell=demo'
-
-# Create a directory
-curl -X POST 'http://127.0.0.1:8080/mkdir/workspace/tmp?cell=demo'
-
-# Delete a file
-curl -X DELETE 'http://127.0.0.1:8080/fs/workspace/hello.txt?cell=demo'
+npm run chat --workspace @example/computer-celld
 ```
 
-Routes:
-
-```
-PUT    /fs/workspace/<path>          raw request body -> /workspace/<path>
-GET    /fs/workspace/<path>          read /workspace/<path>
-DELETE /fs/workspace/<path>          delete a file; add ?recursive=1 for dirs
-GET    /ls/workspace/<dir>           JSON directory listing
-POST   /mkdir/workspace/<dir>        mkdir -p
-POST   /exec                         JavaScript module execution via celld Worker Loader
-```
-
-## JavaScript backend
-
-Start celld with `CELLD_WORKER_LOADER=LOADER` and call `/exec`:
+Each `--name` selects a separate agent with its own chat history and Workspace:
 
 ```sh
-curl -X POST 'http://127.0.0.1:8080/exec?cell=demo' \
-  -H 'content-type: application/json' \
-  -d '{"source":"console.log(\"running\"); export default (input, ctx) => ({ doubled: input.n * 2, cwd: ctx.cwd, name: ctx.env.NAME })","input":{"n":21},"env":{"NAME":"celld"}}'
+npm run chat --workspace @example/computer-celld -- --name demo
 ```
 
-Expected shape:
+Client options:
 
-```json
-{
-  "status": "completed",
-  "exitCode": 0,
-  "value": { "doubled": 42 }
-}
-```
+- `--worker URL` or `CELLD_WORKER` selects the celld HTTP endpoint.
+- `--name NAME` or `CELLD_AGENT_NAME` selects the agent instance.
+- `--title TITLE` changes the terminal title.
 
-User modules can either default-export a value or a function. If the default
-export is a function, it is called as `default(input, ctx)`. The current `ctx`
-shape is:
+The same client is available as the `celld-chat` package binary.
 
-```ts
-interface CelldExecContext {
-  env: Record<string, string>;
-  cwd: string;
-  stdin: string;
-  fs: {
-    readFile(): never;
-    writeFile(): never;
-    readdir(): never;
-    mkdir(): never;
-    rm(): never;
-    stat(): never;
-    exists(): never;
-    ls(): never;
-    find(): never;
-    grep(): never;
-  };
-}
-```
-
-`ctx.fs` is present but intentionally throws a descriptive error today. I tried
-passing a host filesystem `RpcTarget` into the loaded worker as a second step;
-celld v0.1.0 rejected that capability argument with the same structured-clone
-failure as the full Computer bridge. The outer HTTP `/fs` routes are the working
-filesystem API for now.
-
-The backend intentionally uses static imports in the generated runner because
-celld v0.1.0 does not support dynamic `import("entry.js")` in loaded workers.
-Loaded workers also need a default `fetch` export, so the runner includes a tiny
-`fetch() { return new Response("ok") }` handler and exposes the evaluator as a
-named `WorkerEntrypoint`.
-
-## Agents SDK attempt
-
-`FilesystemAgent` is included as a smoke-test attempt for the Cloudflare Agents
-SDK on celld. It constructs a filesystem-only Computer Workspace and calls
-`createAITools({ workspace, assets: false })`.
-
-Routes:
+For a noninteractive chat transport check, run:
 
 ```sh
-curl 'http://127.0.0.1:8080/agents/filesystem-agent/demo'
-curl 'http://127.0.0.1:8080/agents/filesystem-agent/demo/tools'
+npm run smoke --workspace @example/computer-celld
 ```
 
-Status: the Worker bundles and deploys with celld once the `path` npm polyfill
-is present, but a live request currently failed during celld restore with a
-managed SQLite lock:
+The smoke client sends one message over the Agents WebSocket protocol and
+requires the reply to contain `celld smoke reply`. Set `CELLD_PROMPT` to change
+the message or `CELLD_EXPECT` to use a different expected phrase.
 
-```text
-celld restore failed for FilesystemAgent:...: open managed db .../db.sqlite: database is locked
-```
+## Workspace tools
 
-So the Agents SDK wiring is present for iteration, but not counted as validated
-working yet.
+The agent receives these tools from `@cloudflare/computer/tools`:
 
-## Known gaps and follow-ups
+| Tool | Purpose |
+| --- | --- |
+| `read` | Read a Workspace file. |
+| `ls` | List a directory. |
+| `find` | Find paths. |
+| `grep` | Search file contents. |
+| `write` | Create or replace a file. |
+| `edit` | Apply targeted replacements. |
+| `delete` | Remove a file or directory. |
+| `exec` | Run an ECMAScript module in a celld Dynamic Worker. |
 
-The celld Worker Loader works for simple JavaScript execution, but there are a
-few concrete gaps before this example can use Computer's full
-`WorkerJavaScriptBackend` unchanged.
+`exec` is present only when celld injects `env.LOADER`. It uses the
+`celld-javascript` backend in `src/celld-javascript-backend.ts`.
 
-### 1. Host capability stubs cannot cross into the loaded worker yet
+## JavaScript backend limits
 
-Computer's full backend passes a `WorkspaceRuntimeBridge` capability object into
-the Dynamic Worker so user code can call back into the host Durable Object for
-filesystem, module resolution, stdout/stderr events, and other runtime services.
-Under celld v0.1.0, that argument failed during the loaded-worker RPC call:
+The celld Worker Loader can run ECMAScript modules with JSON input and output.
+The module's default export receives `(input, ctx)`, where `ctx` includes
+`env`, `cwd`, and `stdin`.
 
-```text
-DataCloneError: () => {} could not be cloned
-```
+The backend does not yet provide the full Computer
+`WorkerJavaScriptBackend` bridge:
 
-I also tried a smaller filesystem-only `RpcTarget` intended to back `ctx.fs`;
-it failed with the same clone error. For now, `CelldJavaScriptBackend` only
-passes plain structured-clone data (`input`, `env`, `cwd`, `stdin`) and returns
-a plain JSON result plus buffered output.
+- Capability stubs cannot cross into the loaded Worker, so `ctx.fs` methods
+  throw and durable `node:fs/promises` is unavailable there.
+- Output is buffered until execution finishes instead of streamed live.
+- The generated runner uses a static import and a small default `fetch` export
+  to match celld v0.1.0's Worker Loader behavior.
 
-Follow-up: celld's Worker Loader RPC needs to support passing capability stubs
-(or a documented equivalent) as named-Entrypoint arguments between the host
-Worker and a loaded Worker.
+The host-side file tools remain fully functional because they operate directly
+on the Workspace owned by `CelldAgent`.
 
-### 2. No durable filesystem inside loaded JavaScript yet
-
-Because the host bridge cannot be passed, loaded code cannot import Computer's
-durable `node:fs/promises` shim. The `ctx.fs` object is present to reserve the
-intended API shape, but every method currently throws a descriptive error.
-celld's native `node:fs` compatibility is not a replacement: it is intentionally
-partial and reads return `ENOENT`.
-
-Working filesystem access today is the outer HTTP API:
-
-```text
-PUT    /fs/workspace/<path>
-GET    /fs/workspace/<path>
-DELETE /fs/workspace/<path>
-GET    /ls/workspace/<dir>
-POST   /mkdir/workspace/<dir>
-```
-
-Follow-up: once capability stubs can cross into loaded workers, wire `ctx.fs`
-first. After that, evaluate whether Computer's existing durable
-`node:fs/promises` module bridge can be reused unchanged.
-
-### 3. Output is buffered, not streamed live
-
-Computer's full backend streams runtime events as they happen. This example
-captures `console.log/info` as stdout and `console.warn/error` as stderr inside
-the loaded Worker, then returns those buffers when the function completes.
-
-Follow-up: support returning/transferring a stream or event capability from the
-loaded Worker so `/exec` can expose live stdout/stderr and long-running task
-status.
-
-### 4. Loaded-worker module loading differs from Workerd
-
-Two celld Worker Loader differences are handled in the example runner:
-
-- Dynamic `import("entry.js")` failed under celld v0.1.0, so the runner uses a
-  static `import * as userModule from "entry.js"`.
-- The loaded Worker needed a default `fetch` export even though execution uses a
-  named `WorkerEntrypoint`, so the runner exports both `Runner` and a tiny
-  default `fetch()` handler.
-
-Follow-up: decide whether these are intended celld constraints or compatibility
-bugs. If they are fixed, the generated runner can become closer to Computer's
-normal Worker JavaScript backend.
-
-### 5. Agents SDK is bundled but not validated at runtime
-
-`FilesystemAgent` bundles and deploys with celld once the `path` npm polyfill is
-present, but a live Agent request hit a celld managed-SQLite restore failure:
-
-```text
-celld restore failed for FilesystemAgent:...: open managed db .../db.sqlite: database is locked
-```
-
-Follow-up: investigate celld's managed SQLite locking/restore path with Agents
-SDK Durable Objects. The basic Worker and `CelldWorkspace` Durable Object paths
-are validated; the Agent Durable Object is not yet counted as working.
-
-### Current validation matrix
-
-| Feature | Status | Notes |
-| --- | --- | --- |
-| Local S3 shim | Working | Supports the S3 subset celld uses for local deploy/run. |
-| HTTP filesystem API | Working | Validated against actual celld with the local S3 shim. |
-| `/exec` simple JavaScript | Working | Uses celld Worker Loader + named `WorkerEntrypoint`. |
-| `default(input, ctx)` | Working | `ctx.env`, `ctx.cwd`, and `ctx.stdin` are available. |
-| `ctx.fs` in loaded JavaScript | Gap | Placeholder only; host capability passing fails to clone. |
-| Computer `WorkerJavaScriptBackend` unchanged | Gap | Blocked on host bridge/capability passing. |
-| Live stdout/stderr streaming | Gap | Output is buffered until completion. |
-| Agents SDK route | Gap | Bundles/deploys, but live request hit SQLite lock. |
-
-## Local S3 shim
+## Local storage
 
 `script/local-s3-shim.mjs` implements the small path-style S3 subset celld uses
-for local development:
-
-- `PUT`, `GET`, `HEAD`, `DELETE` object requests
-- `GET ?list-type=2&prefix=...` listings
-- `If-Match` / `If-None-Match: *` conditional writes
-- `ETag` and `x-amz-meta-*` headers
-
-It is intentionally a development shim, not a complete S3 server. The on-disk
-layout is `.celld-s3/<bucket>/<key>`.
+for local deployment and state replication. It stores data under
+`.celld-s3/`. The shim is for development only.
 
 ## Layout
 
-```
+```text
 examples/celld/
-  src/index.ts                    Worker + DO + HTTP filesystem routes
-  src/celld-javascript-backend.ts celld Worker Loader module backend
-  script/local-s3-shim.mjs        tiny filesystem-backed S3-compatible endpoint
-  script/local-dev.mjs            start shim, deploy, and run celld locally
-  wrangler.jsonc                  celld-supported Wrangler config subset
+  cli/chat.mjs                    AI SDK terminal client
+  src/index.ts                    chat agent and Worker entrypoint
+  src/celld-javascript-backend.ts celld Worker Loader runtime backend
+  script/local-s3-shim.mjs        local S3-compatible endpoint
+  script/local-dev.mjs            deploy and run celld locally
+  script/smoke.mjs                noninteractive WebSocket chat check
+  wrangler.jsonc                  celld-supported Worker configuration
 ```

--- a/examples/celld/cli/chat.mjs
+++ b/examples/celld/cli/chat.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+// Open an AI SDK terminal chat connected to the CelldAgent Durable Object.
+
+import { argv, env, exit, stderr } from "node:process";
+
+import { runAgentTUI } from "@ai-sdk/tui";
+import { WebSocketChatTransport } from "agents/chat/react";
+import { AgentClient } from "agents/client";
+
+const { workerUrl, name, title } = parseArgs(argv.slice(2));
+
+let base;
+try {
+  base = new URL(workerUrl);
+} catch {
+  stderr.write(`invalid --worker URL: ${workerUrl}\n`);
+  exit(2);
+}
+
+const secure = base.protocol === "https:" || base.protocol === "wss:";
+const host = `${secure ? "https" : "http"}://${base.host}`;
+const client = new AgentClient({ agent: "CelldAgent", name, host });
+const transport = new WebSocketChatTransport({ agent: client });
+
+stderr.write(`connecting to ${host} (agent "celld-agent", instance "${name}")\n`);
+
+await runAgentTUI({
+  transport,
+  title: title ?? `celld · ${name}`,
+});
+
+function parseArgs(args) {
+  let workerUrl = env.CELLD_WORKER ?? "http://127.0.0.1:8080";
+  let name = env.CELLD_AGENT_NAME ?? "default";
+  let title;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--worker") {
+      workerUrl = args[++i] ?? workerUrl;
+    } else if (arg === "--name") {
+      name = args[++i] ?? name;
+    } else if (arg === "--title") {
+      title = args[++i] ?? title;
+    } else if (arg === "-h" || arg === "--help") {
+      stderr.write("usage: chat [--worker URL] [--name NAME] [--title TITLE]\n");
+      exit(0);
+    }
+  }
+  return { workerUrl: workerUrl.replace(/\/+$/, ""), name, title };
+}

--- a/examples/celld/package.json
+++ b/examples/celld/package.json
@@ -8,11 +8,13 @@
     "shim": "node script/local-s3-shim.mjs --root .celld-s3 --port 9000",
     "dev:local": "node script/local-dev.mjs",
     "deploy:local": "AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local AWS_REGION=us-east-1 celld deploy . --bucket s3://celld-computer --endpoint http://127.0.0.1:9000 --region us-east-1",
-    "celld:local": "AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local AWS_REGION=us-east-1 CELLD_WATCH=.celld-state celld --bucket s3://celld-computer --endpoint http://127.0.0.1:9000 --region us-east-1 --listen 127.0.0.1:8080 --advertise 127.0.0.1:8080",
+    "celld:local": "AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local AWS_REGION=us-east-1 CELLD_WORKER_LOADER=LOADER CELLD_WATCH=.celld-state celld --bucket s3://celld-computer --endpoint http://127.0.0.1:9000 --region us-east-1 --listen 127.0.0.1:8080 --advertise 127.0.0.1:8080",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@cloudflare/computer": "*"
+    "@cloudflare/computer": "*",
+    "agents": "^0.20.1",
+    "path": "^0.12.7"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260616.1",

--- a/examples/celld/package.json
+++ b/examples/celld/package.json
@@ -9,12 +9,22 @@
     "dev:local": "node script/local-dev.mjs",
     "deploy:local": "AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local AWS_REGION=us-east-1 celld deploy . --bucket s3://celld-computer --endpoint http://127.0.0.1:9000 --region us-east-1",
     "celld:local": "AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local AWS_REGION=us-east-1 CELLD_WORKER_LOADER=LOADER CELLD_WATCH=.celld-state celld --bucket s3://celld-computer --endpoint http://127.0.0.1:9000 --region us-east-1 --listen 127.0.0.1:8080 --advertise 127.0.0.1:8080",
+    "chat": "node cli/chat.mjs",
+    "smoke": "node script/smoke.mjs",
     "typecheck": "tsc --noEmit"
   },
+  "bin": {
+    "celld-chat": "./cli/chat.mjs"
+  },
   "dependencies": {
+    "@ai-sdk/react": "^4.0.45",
+    "@ai-sdk/tui": "^1.0.43",
+    "@cloudflare/ai-chat": "^0.10.1",
     "@cloudflare/computer": "*",
-    "agents": "^0.20.1",
-    "path": "^0.12.7"
+    "agents": "^0.20.0",
+    "ai": "^7.0.0",
+    "path": "^0.12.7",
+    "workers-ai-provider": "^4.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260616.1",

--- a/examples/celld/package.json
+++ b/examples/celld/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@example/computer-celld",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Prototype @cloudflare/computer Workspace running on celld with a local S3-compatible shim.",
+  "scripts": {
+    "shim": "node script/local-s3-shim.mjs --root .celld-s3 --port 9000",
+    "dev:local": "node script/local-dev.mjs",
+    "deploy:local": "AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local AWS_REGION=us-east-1 celld deploy . --bucket s3://celld-computer --endpoint http://127.0.0.1:9000 --region us-east-1",
+    "celld:local": "AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local AWS_REGION=us-east-1 CELLD_WATCH=.celld-state celld --bucket s3://celld-computer --endpoint http://127.0.0.1:9000 --region us-east-1 --listen 127.0.0.1:8080 --advertise 127.0.0.1:8080",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@cloudflare/computer": "*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260616.1",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/celld/script/local-dev.mjs
+++ b/examples/celld/script/local-dev.mjs
@@ -7,6 +7,7 @@ const env = {
   AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID || "local",
   AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY || "local",
   AWS_REGION: process.env.AWS_REGION || "us-east-1",
+  CELLD_WORKER_LOADER: process.env.CELLD_WORKER_LOADER || "LOADER",
   CELLD_WATCH: process.env.CELLD_WATCH || ".celld-state",
 };
 

--- a/examples/celld/script/local-dev.mjs
+++ b/examples/celld/script/local-dev.mjs
@@ -11,10 +11,20 @@ const env = {
   CELLD_WATCH: process.env.CELLD_WATCH || ".celld-state",
 };
 
+for (const name of ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_API_TOKEN"]) {
+  const value = process.env[`CELLD_VAR_${name}`] || process.env[name];
+  if (value) env[`CELLD_VAR_${name}`] = value;
+}
+
 const children = new Set();
 
 function start(name, command, args, options = {}) {
-  const child = spawn(command, args, { stdio: "inherit", env, shell: process.platform === "win32", ...options });
+  const child = spawn(command, args, {
+    stdio: "inherit",
+    env,
+    shell: process.platform === "win32",
+    ...options,
+  });
   children.add(child);
   child.on("exit", (code, signal) => {
     children.delete(child);
@@ -29,7 +39,9 @@ function start(name, command, args, options = {}) {
 function run(name, command, args) {
   return new Promise((resolve, reject) => {
     const child = start(name, command, args, { allowExit: true });
-    child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`${name} exited ${code}`))));
+    child.on("exit", (code) =>
+      code === 0 ? resolve() : reject(new Error(`${name} exited ${code}`)),
+    );
   });
 }
 
@@ -41,7 +53,13 @@ function shutdown(code = 0) {
 process.on("SIGINT", () => shutdown(130));
 process.on("SIGTERM", () => shutdown(143));
 
-start("local-s3-shim", process.execPath, ["script/local-s3-shim.mjs", "--root", ".celld-s3", "--port", "9000"]);
+start("local-s3-shim", process.execPath, [
+  "script/local-s3-shim.mjs",
+  "--root",
+  ".celld-s3",
+  "--port",
+  "9000",
+]);
 await delay(300);
 
 await run("celld deploy", "celld", [
@@ -54,6 +72,12 @@ await run("celld deploy", "celld", [
   "--region",
   "us-east-1",
 ]);
+
+if (!env.CELLD_VAR_CLOUDFLARE_ACCOUNT_ID || !env.CELLD_VAR_CLOUDFLARE_API_TOKEN) {
+  console.warn(
+    "Cloudflare credentials are unset; the agent can connect, but model requests will fail.",
+  );
+}
 
 start("celld", "celld", [
   "--bucket",
@@ -69,4 +93,4 @@ start("celld", "celld", [
 ]);
 
 console.log("\ncelld is starting on http://127.0.0.1:8080");
-console.log("Try: curl http://127.0.0.1:8080/\n");
+console.log("Open the terminal client with `npm run chat`.\n");

--- a/examples/celld/script/local-dev.mjs
+++ b/examples/celld/script/local-dev.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+
+const env = {
+  ...process.env,
+  AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID || "local",
+  AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY || "local",
+  AWS_REGION: process.env.AWS_REGION || "us-east-1",
+  CELLD_WATCH: process.env.CELLD_WATCH || ".celld-state",
+};
+
+const children = new Set();
+
+function start(name, command, args, options = {}) {
+  const child = spawn(command, args, { stdio: "inherit", env, shell: process.platform === "win32", ...options });
+  children.add(child);
+  child.on("exit", (code, signal) => {
+    children.delete(child);
+    if (!options.allowExit && code !== 0) {
+      console.error(`${name} exited with ${signal || code}`);
+      shutdown(code || 1);
+    }
+  });
+  return child;
+}
+
+function run(name, command, args) {
+  return new Promise((resolve, reject) => {
+    const child = start(name, command, args, { allowExit: true });
+    child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`${name} exited ${code}`))));
+  });
+}
+
+function shutdown(code = 0) {
+  for (const child of children) child.kill("SIGTERM");
+  setTimeout(() => process.exit(code), 200).unref();
+}
+
+process.on("SIGINT", () => shutdown(130));
+process.on("SIGTERM", () => shutdown(143));
+
+start("local-s3-shim", process.execPath, ["script/local-s3-shim.mjs", "--root", ".celld-s3", "--port", "9000"]);
+await delay(300);
+
+await run("celld deploy", "celld", [
+  "deploy",
+  ".",
+  "--bucket",
+  "s3://celld-computer",
+  "--endpoint",
+  "http://127.0.0.1:9000",
+  "--region",
+  "us-east-1",
+]);
+
+start("celld", "celld", [
+  "--bucket",
+  "s3://celld-computer",
+  "--endpoint",
+  "http://127.0.0.1:9000",
+  "--region",
+  "us-east-1",
+  "--listen",
+  "127.0.0.1:8080",
+  "--advertise",
+  "127.0.0.1:8080",
+]);
+
+console.log("\ncelld is starting on http://127.0.0.1:8080");
+console.log("Try: curl http://127.0.0.1:8080/\n");

--- a/examples/celld/script/local-s3-shim.mjs
+++ b/examples/celld/script/local-s3-shim.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
+import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
-import { mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve, sep } from "node:path";
 
 const args = new Map(process.argv.slice(2).map((arg, i, all) => [arg, all[i + 1]]));
@@ -34,10 +34,14 @@ async function route(req, res) {
 
   if (keyParts.length === 0) {
     if (req.method === "HEAD") return empty(res, 200);
-    if (req.method === "GET" && (url.searchParams.has("list-type") || url.searchParams.has("prefix"))) {
+    if (
+      req.method === "GET" &&
+      (url.searchParams.has("list-type") || url.searchParams.has("prefix"))
+    ) {
       return listBucket(res, bucket, url.searchParams.get("prefix") || "");
     }
-    if (req.method === "GET") return xml(res, 200, `<ListBucketResult><Name>${esc(bucket)}</Name></ListBucketResult>`);
+    if (req.method === "GET")
+      return xml(res, 200, `<ListBucketResult><Name>${esc(bucket)}</Name></ListBucketResult>`);
   }
 
   const key = keyParts.join("/");
@@ -59,7 +63,8 @@ async function putObject(req, res, bucket, key) {
   const current = await objectMeta(file).catch(() => null);
 
   const ifNoneMatch = req.headers["if-none-match"];
-  if (ifNoneMatch === "*" && current) return sendError(res, 412, "PreconditionFailed", "object exists");
+  if (ifNoneMatch === "*" && current)
+    return sendError(res, 412, "PreconditionFailed", "object exists");
 
   const ifMatch = req.headers["if-match"];
   if (ifMatch && (!current || stripQuotes(ifMatch) !== stripQuotes(current.etag))) {
@@ -108,7 +113,10 @@ async function listBucket(res, bucket, prefix) {
   const keys = [];
   await walk(bucketRoot, async (file) => {
     if (file.endsWith(".meta.json")) return;
-    const key = file.slice(bucketRoot.length + 1).split(sep).join("/");
+    const key = file
+      .slice(bucketRoot.length + 1)
+      .split(sep)
+      .join("/");
     if (key.startsWith(prefix)) keys.push(key);
   });
   keys.sort();
@@ -131,7 +139,7 @@ async function listBucket(res, bucket, prefix) {
     res,
     200,
     [
-      "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">",
+      '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">',
       `<Name>${esc(bucket)}</Name>`,
       `<Prefix>${esc(prefix)}</Prefix>`,
       "<KeyCount>",
@@ -150,7 +158,11 @@ async function objectMeta(file) {
     return JSON.parse(await readFile(metaFile, "utf8"));
   } catch {
     const body = await readFile(file);
-    return { etag: `"${createHash("md5").update(body).digest("hex")}"`, metadata: {}, mtime: s.mtimeMs };
+    return {
+      etag: `"${createHash("md5").update(body).digest("hex")}"`,
+      metadata: {},
+      mtime: s.mtimeMs,
+    };
   }
 }
 
@@ -207,9 +219,12 @@ function sendError(res, status, code, message) {
 }
 
 function stripQuotes(value) {
-  return String(value).replace(/^W\//, "").replace(/^\"|\"$/g, "");
+  return String(value).replace(/^W\//, "").replace(/^"|"$/g, "");
 }
 
 function esc(value) {
-  return String(value).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]);
+  return String(value).replace(
+    /[&<>"]/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c],
+  );
 }

--- a/examples/celld/script/local-s3-shim.mjs
+++ b/examples/celld/script/local-s3-shim.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { createServer } from "node:http";
+import { mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, join, resolve, sep } from "node:path";
+
+const args = new Map(process.argv.slice(2).map((arg, i, all) => [arg, all[i + 1]]));
+const root = resolve(args.get("--root") || process.env.LOCAL_S3_ROOT || ".celld-s3");
+const port = Number(args.get("--port") || process.env.PORT || 9000);
+const host = args.get("--host") || process.env.HOST || "127.0.0.1";
+
+await mkdir(root, { recursive: true });
+
+const server = createServer(async (req, res) => {
+  try {
+    await route(req, res);
+  } catch (error) {
+    console.error(error);
+    sendError(res, 500, "InternalError", error instanceof Error ? error.message : String(error));
+  }
+});
+
+server.listen(port, host, () => {
+  console.log(`local S3 shim listening on http://${host}:${port} (root ${root})`);
+});
+
+async function route(req, res) {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host || `${host}:${port}`}`);
+  const [bucket, ...keyParts] = url.pathname.split("/").filter(Boolean).map(decodeURIComponent);
+
+  if (!bucket) {
+    return xml(res, 200, `<ListAllMyBucketsResult><Buckets></Buckets></ListAllMyBucketsResult>`);
+  }
+
+  if (keyParts.length === 0) {
+    if (req.method === "HEAD") return empty(res, 200);
+    if (req.method === "GET" && (url.searchParams.has("list-type") || url.searchParams.has("prefix"))) {
+      return listBucket(res, bucket, url.searchParams.get("prefix") || "");
+    }
+    if (req.method === "GET") return xml(res, 200, `<ListBucketResult><Name>${esc(bucket)}</Name></ListBucketResult>`);
+  }
+
+  const key = keyParts.join("/");
+  if (!key || key.includes("..")) return sendError(res, 400, "InvalidKey", "invalid key");
+
+  if (req.method === "PUT") return putObject(req, res, bucket, key);
+  if (req.method === "GET") return getObject(res, bucket, key, false);
+  if (req.method === "HEAD") return getObject(res, bucket, key, true);
+  if (req.method === "DELETE") return deleteObject(res, bucket, key);
+
+  res.setHeader("allow", "GET, HEAD, PUT, DELETE");
+  sendError(res, 405, "MethodNotAllowed", "method not allowed");
+}
+
+async function putObject(req, res, bucket, key) {
+  const body = await readRequest(req);
+  const file = objectPath(bucket, key);
+  const metaFile = `${file}.meta.json`;
+  const current = await objectMeta(file).catch(() => null);
+
+  const ifNoneMatch = req.headers["if-none-match"];
+  if (ifNoneMatch === "*" && current) return sendError(res, 412, "PreconditionFailed", "object exists");
+
+  const ifMatch = req.headers["if-match"];
+  if (ifMatch && (!current || stripQuotes(ifMatch) !== stripQuotes(current.etag))) {
+    return sendError(res, 412, "PreconditionFailed", "etag mismatch");
+  }
+
+  const etag = `"${createHash("md5").update(body).digest("hex")}"`;
+  const metadata = {};
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (name.startsWith("x-amz-meta-")) metadata[name.slice("x-amz-meta-".length)] = String(value);
+  }
+
+  await mkdir(dirname(file), { recursive: true });
+  await writeFile(file, body);
+  await writeFile(metaFile, JSON.stringify({ etag, metadata, mtime: Date.now() }));
+  res.setHeader("etag", etag);
+  empty(res, 200);
+}
+
+async function getObject(res, bucket, key, headOnly) {
+  const file = objectPath(bucket, key);
+  const meta = await objectMeta(file).catch(() => null);
+  if (!meta) return sendError(res, 404, "NoSuchKey", "not found");
+  const s = await stat(file);
+  res.statusCode = 200;
+  res.setHeader("content-length", String(s.size));
+  res.setHeader("etag", meta.etag);
+  res.setHeader("last-modified", s.mtime.toUTCString());
+  for (const [name, value] of Object.entries(meta.metadata || {})) {
+    res.setHeader(`x-amz-meta-${name}`, String(value));
+  }
+  if (headOnly) return res.end();
+  res.end(await readFile(file));
+}
+
+async function deleteObject(res, bucket, key) {
+  const file = objectPath(bucket, key);
+  await rm(file, { force: true });
+  await rm(`${file}.meta.json`, { force: true });
+  empty(res, 204);
+}
+
+async function listBucket(res, bucket, prefix) {
+  const bucketRoot = safeJoin(root, bucket);
+  await mkdir(bucketRoot, { recursive: true });
+  const keys = [];
+  await walk(bucketRoot, async (file) => {
+    if (file.endsWith(".meta.json")) return;
+    const key = file.slice(bucketRoot.length + 1).split(sep).join("/");
+    if (key.startsWith(prefix)) keys.push(key);
+  });
+  keys.sort();
+  const contents = await Promise.all(
+    keys.map(async (key) => {
+      const file = objectPath(bucket, key);
+      const [s, meta] = await Promise.all([stat(file), objectMeta(file)]);
+      return [
+        "<Contents>",
+        `<Key>${esc(key)}</Key>`,
+        `<LastModified>${s.mtime.toISOString()}</LastModified>`,
+        `<ETag>${esc(meta.etag)}</ETag>`,
+        `<Size>${s.size}</Size>`,
+        "<StorageClass>STANDARD</StorageClass>",
+        "</Contents>",
+      ].join("");
+    }),
+  );
+  xml(
+    res,
+    200,
+    [
+      "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">",
+      `<Name>${esc(bucket)}</Name>`,
+      `<Prefix>${esc(prefix)}</Prefix>`,
+      "<KeyCount>",
+      String(keys.length),
+      "</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated>",
+      ...contents,
+      "</ListBucketResult>",
+    ].join(""),
+  );
+}
+
+async function objectMeta(file) {
+  const s = await stat(file);
+  const metaFile = `${file}.meta.json`;
+  try {
+    return JSON.parse(await readFile(metaFile, "utf8"));
+  } catch {
+    const body = await readFile(file);
+    return { etag: `"${createHash("md5").update(body).digest("hex")}"`, metadata: {}, mtime: s.mtimeMs };
+  }
+}
+
+function objectPath(bucket, key) {
+  return safeJoin(safeJoin(root, bucket), key);
+}
+
+function safeJoin(base, child) {
+  const out = resolve(base, child);
+  const normalizedBase = resolve(base);
+  if (out !== normalizedBase && !out.startsWith(`${normalizedBase}${sep}`)) {
+    throw new Error(`path escape: ${child}`);
+  }
+  return out;
+}
+
+async function walk(dir, visit) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) await walk(path, visit);
+    else if (entry.isFile()) await visit(path);
+  }
+}
+
+function readRequest(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+function empty(res, status) {
+  res.statusCode = status;
+  res.end();
+}
+
+function xml(res, status, body) {
+  res.statusCode = status;
+  res.setHeader("content-type", "application/xml");
+  res.end(body);
+}
+
+function sendError(res, status, code, message) {
+  xml(res, status, `<Error><Code>${esc(code)}</Code><Message>${esc(message)}</Message></Error>`);
+}
+
+function stripQuotes(value) {
+  return String(value).replace(/^W\//, "").replace(/^\"|\"$/g, "");
+}
+
+function esc(value) {
+  return String(value).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]);
+}

--- a/examples/celld/script/smoke.mjs
+++ b/examples/celld/script/smoke.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+// Send one chat message through the Agents WebSocket transport and require a reply.
+
+import assert from "node:assert/strict";
+import process from "node:process";
+
+import { WebSocketChatTransport } from "agents/chat/react";
+import { AgentClient } from "agents/client";
+
+const host = (process.env.CELLD_WORKER ?? "http://127.0.0.1:8080").replace(/\/+$/, "");
+const name = process.env.CELLD_AGENT_NAME ?? "smoke";
+const expected = process.env.CELLD_EXPECT ?? "celld smoke reply";
+const prompt = process.env.CELLD_PROMPT ?? "Reply with the smoke-test phrase.";
+const timeoutMs = Number(process.env.CELLD_SMOKE_TIMEOUT_MS ?? "15000");
+
+const client = new AgentClient({ agent: "CelldAgent", name, host });
+const transport = new WebSocketChatTransport({ agent: client });
+
+try {
+  await withTimeout(client.ready, timeoutMs, "agent connection");
+
+  const stream = await transport.sendMessages({
+    trigger: "submit-message",
+    chatId: crypto.randomUUID(),
+    messageId: undefined,
+    messages: [
+      {
+        id: crypto.randomUUID(),
+        role: "user",
+        parts: [{ type: "text", text: prompt }],
+      },
+    ],
+    abortSignal: AbortSignal.timeout(timeoutMs),
+  });
+
+  let reply = "";
+  for await (const chunk of stream) {
+    if (chunk.type === "text-delta") reply += chunk.delta;
+    if (chunk.type === "error") throw new Error(chunk.errorText);
+  }
+
+  assert.ok(
+    reply.toLowerCase().includes(expected.toLowerCase()),
+    `expected reply to contain ${JSON.stringify(expected)}; got ${JSON.stringify(reply)}`,
+  );
+  console.log(reply);
+} finally {
+  client.close();
+}
+
+async function withTimeout(promise, milliseconds, label) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${label} timed out after ${milliseconds}ms`)),
+          milliseconds,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/examples/celld/src/celld-javascript-backend.ts
+++ b/examples/celld/src/celld-javascript-backend.ts
@@ -1,0 +1,267 @@
+import type {
+  ModuleExecutionEnvelope,
+  ModuleExecutionInput,
+  WorkspaceModuleBackend,
+  WorkspaceModuleBackendHandle,
+  WorkspaceModuleBackendHost,
+  WorkspaceRuntimeEvent,
+  WorkspaceRuntimeLoader,
+  WorkspaceRuntimeValue,
+} from "@cloudflare/computer";
+
+export const CELLD_JAVASCRIPT_BACKEND_ID = "celld-javascript";
+const MOUNT_ROOT = "/workspace";
+
+export interface CelldJavaScriptBackendOptions {
+  id?: string;
+  compatibilityDate?: string;
+  compatibilityFlags?: string[];
+  cpuMs?: number;
+  globalOutbound?: null;
+}
+
+/**
+ * A small Computer module backend that uses celld's experimental Worker Loader.
+ *
+ * The current celld Worker Loader supports fresh dynamic isolates, named
+ * WorkerEntrypoint RPC, static sibling modules, plain JSON env, and no-egress
+ * `globalOutbound: null`. That is enough for callable JavaScript execution.
+ *
+ * The full Computer WorkerJavaScriptBackend also passes a host filesystem bridge
+ * into the loaded worker. celld v0.1.0 currently rejects that bridge with a
+ * DataCloneError, so this backend deliberately exposes only the pieces that are
+ * validated under celld today: structured input/output, captured console output,
+ * `ctx.env`, `ctx.cwd`, `ctx.stdin`, and a descriptive `ctx.fs` placeholder.
+ */
+export class CelldJavaScriptBackend implements WorkspaceModuleBackend {
+  readonly protocol = "module" as const;
+  readonly type = "celld-javascript";
+  readonly callable = true;
+  readonly id: string;
+
+  readonly compatibilityDate: string;
+  readonly compatibilityFlags: string[];
+  readonly cpuMs: number;
+  readonly globalOutbound: null;
+
+  constructor(
+    private readonly loader: WorkspaceRuntimeLoader,
+    options: CelldJavaScriptBackendOptions = {},
+  ) {
+    this.id = options.id ?? CELLD_JAVASCRIPT_BACKEND_ID;
+    this.compatibilityDate = options.compatibilityDate ?? "2026-05-26";
+    this.compatibilityFlags = options.compatibilityFlags ?? ["nodejs_compat", "js_rpc"];
+    this.cpuMs = options.cpuMs ?? 30_000;
+    this.globalOutbound = options.globalOutbound ?? null;
+  }
+
+  async connect(_host: WorkspaceModuleBackendHost): Promise<WorkspaceModuleBackendHandle> {
+    return new CelldJavaScriptBackendHandle(this.loader, {
+      id: this.id,
+      compatibilityDate: this.compatibilityDate,
+      compatibilityFlags: this.compatibilityFlags,
+      cpuMs: this.cpuMs,
+      globalOutbound: this.globalOutbound,
+    });
+  }
+}
+
+class CelldJavaScriptBackendHandle implements WorkspaceModuleBackendHandle {
+  private readonly records = new Map<string, WorkspaceRuntimeEvent[]>();
+
+  constructor(
+    private readonly loader: WorkspaceRuntimeLoader,
+    private readonly options: Required<CelldJavaScriptBackendOptions> & { id: string },
+  ) {}
+
+  async exec(input: ModuleExecutionInput): Promise<ModuleExecutionEnvelope> {
+    const id = input.id ?? crypto.randomUUID();
+    const events = await this.run(id, input);
+    this.records.set(id, events);
+    return { id, events: streamEvents(events) };
+  }
+
+  async getExec(input: { id: string; after?: number | "tail" }): Promise<ModuleExecutionEnvelope> {
+    const events = this.records.get(input.id);
+    if (!events) throw Object.assign(new Error(`no such execution: ${input.id}`), { code: "ENOENT" });
+    const after = input.after === "tail" ? Math.max(0, events.length - 1) : input.after ?? 0;
+    return { id: input.id, events: streamEvents(events.filter((event) => event.seq > after)) };
+  }
+
+  async killExec(_input: { id: string }): Promise<void> {
+    throw new Error(`${this.options.id} executions are synchronous and cannot be killed after admission.`);
+  }
+
+  async disposeExec(input: { id: string }): Promise<void> {
+    this.records.delete(input.id);
+  }
+
+  async close(): Promise<void> {
+    this.records.clear();
+  }
+
+  private async run(id: string, input: ModuleExecutionInput): Promise<WorkspaceRuntimeEvent[]> {
+    try {
+      const timeoutMs = input.timeoutMs ?? this.options.cpuMs;
+      const worker = this.loader.load({
+        compatibilityDate: this.options.compatibilityDate,
+        compatibilityFlags: this.options.compatibilityFlags,
+        limits: { cpuMs: timeoutMs },
+        mainModule: "runner.js",
+        modules: {
+          "entry.js": input.source,
+          "runner.js": celldJavaScriptRunner(),
+        },
+        globalOutbound: this.options.globalOutbound,
+      });
+
+      const entrypoint = worker.getEntrypoint("Runner", {
+        limits: { cpuMs: timeoutMs },
+      }) as {
+        evaluate(input: WorkspaceRuntimeValue, meta: CelldRunnerMeta): Promise<CelldRunnerResult>;
+      };
+
+      const meta: CelldRunnerMeta = {
+        env: input.env ?? {},
+        cwd: normalizePath(input.cwd ?? MOUNT_ROOT),
+        stdin: typeof input.stdin === "string" ? input.stdin : decodeBytes(input.stdin),
+      };
+      const result = await entrypoint.evaluate(input.input ?? null, meta);
+
+      const events: WorkspaceRuntimeEvent[] = [];
+      if (result.stdout) events.push({ id, seq: events.length + 1, name: "stdout", value: encode(result.stdout) });
+      if (result.stderr) events.push({ id, seq: events.length + 1, name: "stderr", value: encode(result.stderr) });
+      events.push({ id, seq: events.length + 1, name: "exit", code: 0, result: result.value ?? null });
+      return events;
+    } catch (error) {
+      return [
+        {
+          id,
+          seq: 1,
+          name: "stderr",
+          value: encode(`${error instanceof Error ? error.stack || error.message : String(error)}\n`),
+        },
+        { id, seq: 2, name: "exit", code: 1 },
+      ];
+    }
+  }
+}
+
+interface CelldRunnerMeta {
+  env: Record<string, string>;
+  cwd: string;
+  stdin: string;
+}
+
+interface CelldRunnerResult {
+  value: WorkspaceRuntimeValue;
+  stdout: string;
+  stderr: string;
+}
+
+function celldJavaScriptRunner(): string {
+  return `
+    import { WorkerEntrypoint } from "cloudflare:workers";
+    import * as userModule from "entry.js";
+
+    export class Runner extends WorkerEntrypoint {
+      async evaluate(input, meta) {
+        const stdout = [];
+        const stderr = [];
+        const write = (target, args) => target.push(args.map(formatConsoleValue).join(" ") + "\\n");
+        console.log = (...args) => write(stdout, args);
+        console.info = (...args) => write(stdout, args);
+        console.warn = (...args) => write(stderr, args);
+        console.error = (...args) => write(stderr, args);
+
+        const ctx = {
+          env: meta.env || {},
+          cwd: meta.cwd || "/workspace",
+          stdin: meta.stdin || "",
+          fs: unsupportedFs(),
+        };
+
+        globalThis.process = {
+          env: ctx.env,
+          argv: ["workspace", "entry.js"],
+          cwd: () => ctx.cwd,
+          platform: "linux",
+          stdin: ctx.stdin,
+          stdout: { write: (chunk) => { stdout.push(String(chunk)); return true; } },
+          stderr: { write: (chunk) => { stderr.push(String(chunk)); return true; } },
+        };
+        globalThis.ctx = ctx;
+
+        const result = typeof userModule.default === "function"
+          ? await userModule.default(input, ctx)
+          : userModule.default;
+        return { value: result ?? null, stdout: stdout.join(""), stderr: stderr.join("") };
+      }
+    }
+
+    function unsupportedFs() {
+      const fail = () => {
+        throw new Error(
+          "ctx.fs is not wired yet: celld Worker Loader does not currently clone " +
+          "the host filesystem capability into loaded workers. Use the outer " +
+          "HTTP /fs routes for now."
+        );
+      };
+      return {
+        readFile: fail,
+        writeFile: fail,
+        readdir: fail,
+        mkdir: fail,
+        rm: fail,
+        stat: fail,
+        exists: fail,
+        ls: fail,
+        find: fail,
+        grep: fail,
+      };
+    }
+
+    function formatConsoleValue(value) {
+      if (typeof value === "string") return value;
+      try { return JSON.stringify(value); } catch { return String(value); }
+    }
+
+    export default {
+      fetch() {
+        return new Response("ok");
+      }
+    };
+  `;
+}
+
+function normalizePath(path: string): string {
+  const parts: string[] = [];
+  for (const part of path.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") throw Object.assign(new Error(`path escapes ${MOUNT_ROOT}: ${path}`), { code: "EINVAL" });
+    parts.push(part);
+  }
+  const absolute = `/${parts.join("/")}`;
+  if (absolute !== MOUNT_ROOT && !absolute.startsWith(`${MOUNT_ROOT}/`)) {
+    throw Object.assign(new Error(`path must sit under ${MOUNT_ROOT}: ${path}`), { code: "EINVAL" });
+  }
+  return absolute;
+}
+
+function encode(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function decodeBytes(value: Uint8Array | string | undefined): string {
+  if (value === undefined) return "";
+  return typeof value === "string" ? value : new TextDecoder().decode(value);
+}
+
+function streamEvents(events: WorkspaceRuntimeEvent[]): ReadableStream<WorkspaceRuntimeEvent> {
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) controller.enqueue(event);
+      controller.close();
+    },
+  });
+}

--- a/examples/celld/src/celld-javascript-backend.ts
+++ b/examples/celld/src/celld-javascript-backend.ts
@@ -83,13 +83,16 @@ class CelldJavaScriptBackendHandle implements WorkspaceModuleBackendHandle {
 
   async getExec(input: { id: string; after?: number | "tail" }): Promise<ModuleExecutionEnvelope> {
     const events = this.records.get(input.id);
-    if (!events) throw Object.assign(new Error(`no such execution: ${input.id}`), { code: "ENOENT" });
-    const after = input.after === "tail" ? Math.max(0, events.length - 1) : input.after ?? 0;
+    if (!events)
+      throw Object.assign(new Error(`no such execution: ${input.id}`), { code: "ENOENT" });
+    const after = input.after === "tail" ? Math.max(0, events.length - 1) : (input.after ?? 0);
     return { id: input.id, events: streamEvents(events.filter((event) => event.seq > after)) };
   }
 
   async killExec(_input: { id: string }): Promise<void> {
-    throw new Error(`${this.options.id} executions are synchronous and cannot be killed after admission.`);
+    throw new Error(
+      `${this.options.id} executions are synchronous and cannot be killed after admission.`,
+    );
   }
 
   async disposeExec(input: { id: string }): Promise<void> {
@@ -129,9 +132,17 @@ class CelldJavaScriptBackendHandle implements WorkspaceModuleBackendHandle {
       const result = await entrypoint.evaluate(input.input ?? null, meta);
 
       const events: WorkspaceRuntimeEvent[] = [];
-      if (result.stdout) events.push({ id, seq: events.length + 1, name: "stdout", value: encode(result.stdout) });
-      if (result.stderr) events.push({ id, seq: events.length + 1, name: "stderr", value: encode(result.stderr) });
-      events.push({ id, seq: events.length + 1, name: "exit", code: 0, result: result.value ?? null });
+      if (result.stdout)
+        events.push({ id, seq: events.length + 1, name: "stdout", value: encode(result.stdout) });
+      if (result.stderr)
+        events.push({ id, seq: events.length + 1, name: "stderr", value: encode(result.stderr) });
+      events.push({
+        id,
+        seq: events.length + 1,
+        name: "exit",
+        code: 0,
+        result: result.value ?? null,
+      });
       return events;
     } catch (error) {
       return [
@@ -139,7 +150,9 @@ class CelldJavaScriptBackendHandle implements WorkspaceModuleBackendHandle {
           id,
           seq: 1,
           name: "stderr",
-          value: encode(`${error instanceof Error ? error.stack || error.message : String(error)}\n`),
+          value: encode(
+            `${error instanceof Error ? error.stack || error.message : String(error)}\n`,
+          ),
         },
         { id, seq: 2, name: "exit", code: 1 },
       ];
@@ -238,12 +251,15 @@ function normalizePath(path: string): string {
   const parts: string[] = [];
   for (const part of path.split("/")) {
     if (!part || part === ".") continue;
-    if (part === "..") throw Object.assign(new Error(`path escapes ${MOUNT_ROOT}: ${path}`), { code: "EINVAL" });
+    if (part === "..")
+      throw Object.assign(new Error(`path escapes ${MOUNT_ROOT}: ${path}`), { code: "EINVAL" });
     parts.push(part);
   }
   const absolute = `/${parts.join("/")}`;
   if (absolute !== MOUNT_ROOT && !absolute.startsWith(`${MOUNT_ROOT}/`)) {
-    throw Object.assign(new Error(`path must sit under ${MOUNT_ROOT}: ${path}`), { code: "EINVAL" });
+    throw Object.assign(new Error(`path must sit under ${MOUNT_ROOT}: ${path}`), {
+      code: "EINVAL",
+    });
   }
   return absolute;
 }

--- a/examples/celld/src/celld-javascript-backend.ts
+++ b/examples/celld/src/celld-javascript-backend.ts
@@ -216,8 +216,8 @@ function celldJavaScriptRunner(): string {
       const fail = () => {
         throw new Error(
           "ctx.fs is not wired yet: celld Worker Loader does not currently clone " +
-          "the host filesystem capability into loaded workers. Use the outer " +
-          "HTTP /fs routes for now."
+          "the host filesystem capability into loaded workers. Use the read, " +
+          "write, edit, ls, find, grep, and delete tools outside exec."
         );
       };
       return {

--- a/examples/celld/src/index.ts
+++ b/examples/celld/src/index.ts
@@ -1,0 +1,253 @@
+import { DurableObject } from "cloudflare:workers";
+
+import { type DurableObjectStorageLike, getWorkspace, withWorkspace } from "@cloudflare/computer";
+
+export class CelldWorkspace extends withWorkspace(class extends DurableObject<Env> {}, (self) => {
+  const { ctx, env } = self as unknown as { ctx: DurableObjectState; env: Env };
+  return {
+    storage: ctx.storage as unknown as DurableObjectStorageLike,
+    // No runtime backend for now: celld's current Worker Loader can create
+    // Dynamic Workers, but it does not yet expose enough RPC/clone semantics
+    // for Computer's WorkerJavaScriptBackend bridge. This prototype focuses on
+    // the durable Workspace filesystem.
+    backends: [],
+  };
+}) {
+  async writeFile(path: string, body: ArrayBuffer): Promise<void> {
+    const ws = await getWorkspace(this);
+    await ws.fs.mkdir(parentDirectory(path), { recursive: true });
+    await ws.fs.writeFile(path, new Uint8Array(body));
+  }
+
+  async readFile(path: string): Promise<ArrayBuffer> {
+    const ws = await getWorkspace(this);
+    const stream = await ws.fs.readFile(path, {});
+    return collect(stream);
+  }
+
+  async rm(path: string, options: { recursive?: boolean }): Promise<void> {
+    const ws = await getWorkspace(this);
+    await ws.fs.rm(path, { recursive: options.recursive, force: true });
+  }
+
+  async readdir(path: string, limit: number): Promise<unknown> {
+    const ws = await getWorkspace(this);
+    await ws.fs.mkdir(MOUNT_ROOT, { recursive: true });
+    return ws.fs.readdir(path, { limit });
+  }
+
+  async mkdir(path: string): Promise<void> {
+    const ws = await getWorkspace(this);
+    await ws.fs.mkdir(path, { recursive: true });
+  }
+
+}
+
+interface CelldWorkspaceRpc {
+  writeFile(path: string, body: ArrayBuffer): Promise<void>;
+  readFile(path: string): Promise<ArrayBuffer>;
+  rm(path: string, options: { recursive?: boolean }): Promise<void>;
+  readdir(path: string, limit: number): Promise<unknown>;
+  mkdir(path: string): Promise<void>;
+}
+
+const MOUNT_ROOT = "/workspace";
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    const fileMatch = url.pathname.match(/^\/fs\/(.+)$/);
+    if (fileMatch) {
+      const path = resolveWorkspacePath(fileMatch[1]);
+      if (path === null) return pathError(fileMatch[1]);
+      return handleFile(request, env, cellName(url), path);
+    }
+
+    const listMatch = url.pathname.match(/^\/ls\/(.+)$/);
+    if (listMatch) {
+      const path = resolveWorkspacePath(listMatch[1]);
+      if (path === null) return pathError(listMatch[1]);
+      return handleList(request, env, cellName(url), path);
+    }
+
+    const mkdirMatch = url.pathname.match(/^\/mkdir\/(.+)$/);
+    if (mkdirMatch) {
+      const path = resolveWorkspacePath(mkdirMatch[1]);
+      if (path === null) return pathError(mkdirMatch[1]);
+      return handleMkdir(request, env, cellName(url), path);
+    }
+
+    if (url.pathname === "/" || url.pathname === "") {
+      return new Response(helpText(env), { headers: { "content-type": "text/plain; charset=utf-8" } });
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;
+
+function workspaceStub(env: Env, name: string): CelldWorkspaceRpc {
+  return env.WORKSPACE.get(env.WORKSPACE.idFromName(name)) as unknown as CelldWorkspaceRpc;
+}
+
+async function handleFile(
+  request: Request,
+  env: Env,
+  name: string,
+  path: string,
+): Promise<Response> {
+  const stub = workspaceStub(env, name);
+
+  if (request.method === "GET") {
+    try {
+      return new Response(await stub.readFile(path), {
+        headers: { "content-type": "application/octet-stream" },
+      });
+    } catch (error) {
+      return errorJSON(error, errorCode(error) === "ENOENT" ? 404 : 500);
+    }
+  }
+
+  if (request.method === "PUT") {
+    try {
+      await stub.writeFile(path, await request.arrayBuffer());
+      return new Response(null, { status: 204 });
+    } catch (error) {
+      return errorJSON(error, 500);
+    }
+  }
+
+  if (request.method === "DELETE") {
+    try {
+      await stub.rm(path, { recursive: urlBoolean(request.url, "recursive") });
+      return new Response(null, { status: 204 });
+    } catch (error) {
+      return errorJSON(error, 500);
+    }
+  }
+
+  return new Response("method not allowed", {
+    status: 405,
+    headers: { allow: "GET, PUT, DELETE" },
+  });
+}
+
+async function handleList(
+  request: Request,
+  env: Env,
+  name: string,
+  path: string,
+): Promise<Response> {
+  if (request.method !== "GET") {
+    return new Response("method not allowed", { status: 405, headers: { allow: "GET" } });
+  }
+  try {
+    const entries = await workspaceStub(env, name).readdir(path, numberParam(request.url, "limit") ?? 1024);
+    return json({ cell: name, path, entries });
+  } catch (error) {
+    return errorJSON(error, errorCode(error) === "ENOENT" ? 404 : 500);
+  }
+}
+
+async function handleMkdir(
+  request: Request,
+  env: Env,
+  name: string,
+  path: string,
+): Promise<Response> {
+  if (request.method !== "POST" && request.method !== "PUT") {
+    return new Response("method not allowed", { status: 405, headers: { allow: "POST, PUT" } });
+  }
+  try {
+    await workspaceStub(env, name).mkdir(path);
+    return new Response(null, { status: 204 });
+  } catch (error) {
+    return errorJSON(error, 500);
+  }
+}
+
+function resolveWorkspacePath(rest: string): string | null {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rest);
+  } catch {
+    return null;
+  }
+  const candidate = `/${decoded.replace(/^\/+/, "")}`;
+  if (candidate !== MOUNT_ROOT && !candidate.startsWith(`${MOUNT_ROOT}/`)) return null;
+  if (candidate.split("/").includes("..")) return null;
+  return candidate;
+}
+
+function cellName(url: URL): string {
+  return url.searchParams.get("cell") || "default";
+}
+
+function parentDirectory(path: string): string {
+  const index = path.lastIndexOf("/");
+  return index <= 0 ? MOUNT_ROOT : path.slice(0, index);
+}
+
+function urlBoolean(rawUrl: string, name: string): boolean {
+  const value = new URL(rawUrl).searchParams.get(name);
+  return value === "1" || value === "true";
+}
+
+function numberParam(rawUrl: string, name: string): number | undefined {
+  const value = new URL(rawUrl).searchParams.get(name);
+  if (value === null) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : undefined;
+}
+
+function pathError(rest: string): Response {
+  return errorJSON(new Error(`path must sit under ${MOUNT_ROOT}; got /${rest}`), 400);
+}
+
+function errorCode(error: unknown): string | undefined {
+  return (error as { code?: string }).code;
+}
+
+function errorJSON(error: unknown, status: number): Response {
+  const message = error instanceof Error ? error.message : String(error);
+  return json({ error: message, code: errorCode(error) }, status);
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<ArrayBuffer> {
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+    size += chunk.byteLength;
+  }
+  const out = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out.buffer;
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value, null, 2), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+function helpText(env: Env): string {
+  return [
+    "computer + celld prototype",
+    "",
+    "Persistent filesystem (cell defaults to `default`; pass ?cell=name to shard):",
+    `  PUT    /fs/workspace/<path>         raw body -> ${MOUNT_ROOT}/<path>`,
+    `  GET    /fs/workspace/<path>         read ${MOUNT_ROOT}/<path>`,
+    `  DELETE /fs/workspace/<path>         delete file (add ?recursive=1 for dirs)`,
+    `  GET    /ls/workspace/<dir>          list ${MOUNT_ROOT}/<dir>`,
+    `  POST   /mkdir/workspace/<dir>       mkdir -p ${MOUNT_ROOT}/<dir>`,
+    "",
+    "No runtime backend is configured; this example is filesystem-only.",
+    "",
+  ].join("\n");
+}

--- a/examples/celld/src/index.ts
+++ b/examples/celld/src/index.ts
@@ -1,377 +1,103 @@
-import { DurableObject } from "cloudflare:workers";
-import { Agent, routeAgentRequest } from "agents";
-
+import { AIChatAgent, type OnChatMessageOptions } from "@cloudflare/ai-chat";
 import {
   type DurableObjectStorageLike,
   getWorkspace,
-  Workspace,
-  type WorkspaceRuntimeValue,
+  type WorkspaceRuntimeLoader,
   withWorkspace,
 } from "@cloudflare/computer";
 import { createAITools } from "@cloudflare/computer/tools";
+import { routeAgentRequest } from "agents";
+import { convertToModelMessages, isStepCount, streamText } from "ai";
+import { createWorkersAI } from "workers-ai-provider";
 
 import { CELLD_JAVASCRIPT_BACKEND_ID, CelldJavaScriptBackend } from "./celld-javascript-backend";
 
-export class CelldWorkspace extends withWorkspace(class extends DurableObject<Env> {}, (self) => {
-  const { ctx, env } = self as unknown as { ctx: DurableObjectState; env: Env };
+const MODEL_ID = "@cf/zai-org/glm-5.2";
+
+// Keep the agent's bindings separate from the Worker Env, whose namespace
+// points back to CelldAgent and would make the mixin base type recursive.
+interface CelldAgentEnv {
+  CLOUDFLARE_ACCOUNT_ID: string;
+  CLOUDFLARE_API_TOKEN: string;
+  LOADER?: WorkspaceRuntimeLoader;
+}
+
+class CelldAgentBase extends AIChatAgent<CelldAgentEnv> {
+  protected readonly bindings: CelldAgentEnv;
+
+  constructor(ctx: DurableObjectState, env: CelldAgentEnv) {
+    super(ctx, env);
+    this.bindings = env;
+  }
+}
+
+export class CelldAgent extends withWorkspace(CelldAgentBase, (self) => {
+  const { ctx, env } = self as unknown as { ctx: DurableObjectState; env: CelldAgentEnv };
   return {
     storage: ctx.storage as unknown as DurableObjectStorageLike,
-    // celld's Worker Loader can run Dynamic Workers. This example uses a
-    // small celld-specific JavaScript backend below because the full
-    // WorkerJavaScriptBackend filesystem bridge still needs additional RPC
-    // support in celld.
     backends: env.LOADER ? [new CelldJavaScriptBackend(env.LOADER)] : [],
   };
 }) {
-  async writeFile(path: string, body: ArrayBuffer): Promise<void> {
-    const ws = await getWorkspace(this);
-    await ws.fs.mkdir(parentDirectory(path), { recursive: true });
-    await ws.fs.writeFile(path, new Uint8Array(body));
-  }
-
-  async readFile(path: string): Promise<ArrayBuffer> {
-    const ws = await getWorkspace(this);
-    const stream = await ws.fs.readFile(path, {});
-    return collect(stream);
-  }
-
-  async rm(path: string, options: { recursive?: boolean }): Promise<void> {
-    const ws = await getWorkspace(this);
-    await ws.fs.rm(path, { recursive: options.recursive, force: true });
-  }
-
-  async readdir(path: string, limit: number): Promise<unknown> {
-    const ws = await getWorkspace(this);
-    await ws.fs.mkdir(MOUNT_ROOT, { recursive: true });
-    return ws.fs.readdir(path, { limit });
-  }
-
-  async mkdir(path: string): Promise<void> {
-    const ws = await getWorkspace(this);
-    await ws.fs.mkdir(path, { recursive: true });
-  }
-
-  async exec(request: RunnableExecRequest): Promise<unknown> {
-    const ws = await getWorkspace(this);
-    const handle = await ws.runtime.exec(request.source, {
-      backend: CELLD_JAVASCRIPT_BACKEND_ID,
-      cwd: request.cwd ?? MOUNT_ROOT,
-      input: request.input,
-      env: request.env,
-      stdin: request.stdin,
-      encoding: "utf8",
+  override async onChatMessage(
+    _onFinish: unknown,
+    options?: OnChatMessageOptions,
+  ): Promise<Response> {
+    const workspace = await getWorkspace(this);
+    const tools = createAITools({
+      workspace,
+      assets: false,
+      ...(this.bindings.LOADER
+        ? {
+            shell: {
+              defaultBackend: CELLD_JAVASCRIPT_BACKEND_ID,
+              backends: {
+                [CELLD_JAVASCRIPT_BACKEND_ID]: {
+                  description:
+                    "A celld Dynamic Worker that runs an ECMAScript module with structured input and output. The loaded worker cannot access the workspace filesystem yet.",
+                },
+              },
+            },
+          }
+        : {}),
     });
-    return handle.result();
+    const accountId = this.bindings.CLOUDFLARE_ACCOUNT_ID?.trim();
+    const apiKey = this.bindings.CLOUDFLARE_API_TOKEN?.trim();
+    if (!accountId || !apiKey) {
+      throw new Error("Set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN before starting celld.");
+    }
+    const model = createWorkersAI({ accountId, apiKey })(MODEL_ID);
+    const result = streamText({
+      abortSignal: options?.abortSignal,
+      model,
+      system: [
+        "You are a helpful assistant with a durable workspace rooted at /workspace.",
+        "Use read, ls, find, grep, write, edit, and delete to work with files.",
+        this.bindings.LOADER
+          ? "Use exec for JavaScript modules that do not need filesystem access."
+          : "The JavaScript execution backend is disabled, so do not call exec.",
+      ].join("\n"),
+      messages: await convertToModelMessages(this.messages),
+      tools,
+      stopWhen: isStepCount(10),
+    });
+
+    return result.toUIMessageStreamResponse();
   }
 }
-
-interface ExecRequest {
-  source?: string;
-  input?: WorkspaceRuntimeValue;
-  cwd?: string;
-  env?: Record<string, string>;
-  stdin?: string;
-}
-
-type RunnableExecRequest = Required<Pick<ExecRequest, "source">> & Omit<ExecRequest, "source">;
-
-interface AgentState {
-  requests: number;
-}
-
-export class FilesystemAgent extends Agent<Env, AgentState> {
-  initialState: AgentState = { requests: 0 };
-
-  async onRequest(request: Request): Promise<Response> {
-    const workspace = new Workspace({
-      storage: this.ctx.storage as unknown as DurableObjectStorageLike,
-      backends: [],
-    });
-    const tools = createAITools({ workspace, assets: false });
-    const url = new URL(request.url);
-    const nextState = { requests: (this.state.requests ?? 0) + 1 };
-    this.setState(nextState);
-
-    if (url.pathname.endsWith("/tools")) {
-      return json({
-        agent: "FilesystemAgent",
-        state: nextState,
-        tools: Object.keys(tools),
-        note: "Computer tools construct successfully inside an Agents SDK Agent on celld; runtime exec/publish are intentionally absent.",
-      });
-    }
-
-    if (request.method === "PUT" && url.pathname.endsWith("/file")) {
-      const path = resolveWorkspacePath(url.searchParams.get("path") ?? "");
-      if (path === null) return pathError(url.searchParams.get("path") ?? "");
-      await workspace.fs.mkdir(parentDirectory(path), { recursive: true });
-      await workspace.fs.writeFile(path, new Uint8Array(await request.arrayBuffer()));
-      return new Response(null, { status: 204 });
-    }
-
-    if (request.method === "GET" && url.pathname.endsWith("/file")) {
-      const path = resolveWorkspacePath(url.searchParams.get("path") ?? "");
-      if (path === null) return pathError(url.searchParams.get("path") ?? "");
-      try {
-        const stream = await workspace.fs.readFile(path, {});
-        return new Response(stream, { headers: { "content-type": "application/octet-stream" } });
-      } catch (error) {
-        return errorJSON(error, errorCode(error) === "ENOENT" ? 404 : 500);
-      }
-    }
-
-    return json({
-      agent: "FilesystemAgent",
-      state: nextState,
-      routes: ["GET ./tools", "PUT ./file?path=workspace/<path>", "GET ./file?path=workspace/<path>"],
-    });
-  }
-}
-
-interface CelldWorkspaceRpc {
-  writeFile(path: string, body: ArrayBuffer): Promise<void>;
-  readFile(path: string): Promise<ArrayBuffer>;
-  rm(path: string, options: { recursive?: boolean }): Promise<void>;
-  readdir(path: string, limit: number): Promise<unknown>;
-  mkdir(path: string): Promise<void>;
-  exec(request: RunnableExecRequest): Promise<unknown>;
-}
-
-const MOUNT_ROOT = "/workspace";
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const agentResponse = await routeAgentRequest(request, env);
-    if (agentResponse) return agentResponse;
-
-    const url = new URL(request.url);
-
-    const fileMatch = url.pathname.match(/^\/fs\/(.+)$/);
-    if (fileMatch) {
-      const path = resolveWorkspacePath(fileMatch[1]);
-      if (path === null) return pathError(fileMatch[1]);
-      return handleFile(request, env, cellName(url), path);
-    }
-
-    const listMatch = url.pathname.match(/^\/ls\/(.+)$/);
-    if (listMatch) {
-      const path = resolveWorkspacePath(listMatch[1]);
-      if (path === null) return pathError(listMatch[1]);
-      return handleList(request, env, cellName(url), path);
-    }
-
-    const mkdirMatch = url.pathname.match(/^\/mkdir\/(.+)$/);
-    if (mkdirMatch) {
-      const path = resolveWorkspacePath(mkdirMatch[1]);
-      if (path === null) return pathError(mkdirMatch[1]);
-      return handleMkdir(request, env, cellName(url), path);
-    }
-
-    if (url.pathname === "/exec") {
-      return handleExec(request, env, cellName(url));
-    }
-
-    if (url.pathname === "/" || url.pathname === "") {
-      return new Response(helpText(env), { headers: { "content-type": "text/plain; charset=utf-8" } });
-    }
-
-    return new Response("not found", { status: 404 });
+    return (
+      (await routeAgentRequest(request, env)) ??
+      new Response(
+        [
+          "computer + celld chat agent",
+          "",
+          "Connect with `npm run chat`, or point an Agents chat client at",
+          "/agents/celld-agent/<name>.",
+        ].join("\n"),
+        { headers: { "content-type": "text/plain; charset=utf-8" } },
+      )
+    );
   },
 } satisfies ExportedHandler<Env>;
-
-function workspaceStub(env: Env, name: string): CelldWorkspaceRpc {
-  return env.WORKSPACE.get(env.WORKSPACE.idFromName(name)) as unknown as CelldWorkspaceRpc;
-}
-
-async function handleFile(
-  request: Request,
-  env: Env,
-  name: string,
-  path: string,
-): Promise<Response> {
-  const stub = workspaceStub(env, name);
-
-  if (request.method === "GET") {
-    try {
-      return new Response(await stub.readFile(path), {
-        headers: { "content-type": "application/octet-stream" },
-      });
-    } catch (error) {
-      return errorJSON(error, errorCode(error) === "ENOENT" ? 404 : 500);
-    }
-  }
-
-  if (request.method === "PUT") {
-    try {
-      await stub.writeFile(path, await request.arrayBuffer());
-      return new Response(null, { status: 204 });
-    } catch (error) {
-      return errorJSON(error, 500);
-    }
-  }
-
-  if (request.method === "DELETE") {
-    try {
-      await stub.rm(path, { recursive: urlBoolean(request.url, "recursive") });
-      return new Response(null, { status: 204 });
-    } catch (error) {
-      return errorJSON(error, 500);
-    }
-  }
-
-  return new Response("method not allowed", {
-    status: 405,
-    headers: { allow: "GET, PUT, DELETE" },
-  });
-}
-
-async function handleList(
-  request: Request,
-  env: Env,
-  name: string,
-  path: string,
-): Promise<Response> {
-  if (request.method !== "GET") {
-    return new Response("method not allowed", { status: 405, headers: { allow: "GET" } });
-  }
-  try {
-    const entries = await workspaceStub(env, name).readdir(path, numberParam(request.url, "limit") ?? 1024);
-    return json({ cell: name, path, entries });
-  } catch (error) {
-    return errorJSON(error, errorCode(error) === "ENOENT" ? 404 : 500);
-  }
-}
-
-async function handleMkdir(
-  request: Request,
-  env: Env,
-  name: string,
-  path: string,
-): Promise<Response> {
-  if (request.method !== "POST" && request.method !== "PUT") {
-    return new Response("method not allowed", { status: 405, headers: { allow: "POST, PUT" } });
-  }
-  try {
-    await workspaceStub(env, name).mkdir(path);
-    return new Response(null, { status: 204 });
-  } catch (error) {
-    return errorJSON(error, 500);
-  }
-}
-
-async function handleExec(request: Request, env: Env, name: string): Promise<Response> {
-  if (request.method !== "POST") {
-    return new Response("method not allowed", { status: 405, headers: { allow: "POST" } });
-  }
-  if (!env.LOADER) {
-    return errorJSON(new Error("Dynamic Worker loader disabled; start celld with CELLD_WORKER_LOADER=LOADER"), 501);
-  }
-  let body: ExecRequest;
-  try {
-    body = (await request.json()) as ExecRequest;
-  } catch {
-    return errorJSON(new Error("invalid JSON body"), 400);
-  }
-  if (typeof body.source !== "string" || body.source.length === 0) {
-    return errorJSON(new Error("must provide source"), 400);
-  }
-  try {
-    return json(await workspaceStub(env, name).exec(body as RunnableExecRequest));
-  } catch (error) {
-    return errorJSON(error, 500);
-  }
-}
-
-function resolveWorkspacePath(rest: string): string | null {
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(rest);
-  } catch {
-    return null;
-  }
-  const candidate = `/${decoded.replace(/^\/+/, "")}`;
-  if (candidate !== MOUNT_ROOT && !candidate.startsWith(`${MOUNT_ROOT}/`)) return null;
-  if (candidate.split("/").includes("..")) return null;
-  return candidate;
-}
-
-function cellName(url: URL): string {
-  return url.searchParams.get("cell") || "default";
-}
-
-function parentDirectory(path: string): string {
-  const index = path.lastIndexOf("/");
-  return index <= 0 ? MOUNT_ROOT : path.slice(0, index);
-}
-
-function urlBoolean(rawUrl: string, name: string): boolean {
-  const value = new URL(rawUrl).searchParams.get(name);
-  return value === "1" || value === "true";
-}
-
-function numberParam(rawUrl: string, name: string): number | undefined {
-  const value = new URL(rawUrl).searchParams.get(name);
-  if (value === null) return undefined;
-  const n = Number(value);
-  return Number.isFinite(n) && n > 0 ? Math.floor(n) : undefined;
-}
-
-function pathError(rest: string): Response {
-  return errorJSON(new Error(`path must sit under ${MOUNT_ROOT}; got /${rest}`), 400);
-}
-
-function errorCode(error: unknown): string | undefined {
-  return (error as { code?: string }).code;
-}
-
-function errorJSON(error: unknown, status: number): Response {
-  const message = error instanceof Error ? error.message : String(error);
-  return json({ error: message, code: errorCode(error) }, status);
-}
-
-async function collect(stream: ReadableStream<Uint8Array>): Promise<ArrayBuffer> {
-  const chunks: Uint8Array[] = [];
-  let size = 0;
-  for await (const chunk of stream) {
-    chunks.push(chunk);
-    size += chunk.byteLength;
-  }
-  const out = new Uint8Array(size);
-  let offset = 0;
-  for (const chunk of chunks) {
-    out.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return out.buffer;
-}
-
-function json(value: unknown, status = 200): Response {
-  return new Response(JSON.stringify(value, null, 2), {
-    status,
-    headers: { "content-type": "application/json; charset=utf-8" },
-  });
-}
-
-function helpText(env: Env): string {
-  return [
-    "computer + celld prototype",
-    "",
-    "Persistent filesystem (cell defaults to `default`; pass ?cell=name to shard):",
-    `  PUT    /fs/workspace/<path>         raw body -> ${MOUNT_ROOT}/<path>`,
-    `  GET    /fs/workspace/<path>         read ${MOUNT_ROOT}/<path>`,
-    `  DELETE /fs/workspace/<path>         delete file (add ?recursive=1 for dirs)`,
-    `  GET    /ls/workspace/<dir>          list ${MOUNT_ROOT}/<dir>`,
-    `  POST   /mkdir/workspace/<dir>       mkdir -p ${MOUNT_ROOT}/<dir>`,
-    "",
-    env.LOADER
-      ? "Dynamic Worker backend: POST /exec { source, input?, cwd?, env?, stdin? }"
-      : "Dynamic Worker backend disabled (set CELLD_WORKER_LOADER=LOADER before starting celld).",
-    "",
-    "Agents SDK smoke route:",
-    "  GET    /agents/filesystem-agent/<name>",
-    "  GET    /agents/filesystem-agent/<name>/tools",
-    "  PUT    /agents/filesystem-agent/<name>/file?path=workspace/<path>",
-    "  GET    /agents/filesystem-agent/<name>/file?path=workspace/<path>",
-    "",
-  ].join("\n");
-}

--- a/examples/celld/src/index.ts
+++ b/examples/celld/src/index.ts
@@ -1,16 +1,31 @@
 import { DurableObject } from "cloudflare:workers";
+import { Agent, routeAgentRequest } from "agents";
 
-import { type DurableObjectStorageLike, getWorkspace, withWorkspace } from "@cloudflare/computer";
+import {
+  type DurableObjectStorageLike,
+  getWorkspace,
+  type ModuleExecutionEnvelope,
+  type ModuleExecutionInput,
+  Workspace,
+  type WorkspaceModuleBackend,
+  type WorkspaceModuleBackendHandle,
+  type WorkspaceModuleBackendHost,
+  type WorkspaceRuntimeEvent,
+  type WorkspaceRuntimeLoader,
+  type WorkspaceRuntimeValue,
+  withWorkspace,
+} from "@cloudflare/computer";
+import { createAITools } from "@cloudflare/computer/tools";
 
 export class CelldWorkspace extends withWorkspace(class extends DurableObject<Env> {}, (self) => {
   const { ctx, env } = self as unknown as { ctx: DurableObjectState; env: Env };
   return {
     storage: ctx.storage as unknown as DurableObjectStorageLike,
-    // No runtime backend for now: celld's current Worker Loader can create
-    // Dynamic Workers, but it does not yet expose enough RPC/clone semantics
-    // for Computer's WorkerJavaScriptBackend bridge. This prototype focuses on
-    // the durable Workspace filesystem.
-    backends: [],
+    // celld's Worker Loader can run Dynamic Workers. This example uses a
+    // small celld-specific JavaScript backend below because the full
+    // WorkerJavaScriptBackend filesystem bridge still needs additional RPC
+    // support in celld.
+    backends: env.LOADER ? [new CelldJavaScriptBackend(env.LOADER)] : [],
   };
 }) {
   async writeFile(path: string, body: ArrayBuffer): Promise<void> {
@@ -41,6 +56,169 @@ export class CelldWorkspace extends withWorkspace(class extends DurableObject<En
     await ws.fs.mkdir(path, { recursive: true });
   }
 
+  async exec(request: RunnableExecRequest): Promise<unknown> {
+    const ws = await getWorkspace(this);
+    const handle = await ws.runtime.exec(request.source, {
+      backend: "celld-javascript",
+      cwd: request.cwd ?? MOUNT_ROOT,
+      input: request.input,
+      env: request.env,
+      stdin: request.stdin,
+      encoding: "utf8",
+    });
+    return handle.result();
+  }
+}
+
+interface ExecRequest {
+  source?: string;
+  input?: WorkspaceRuntimeValue;
+  cwd?: string;
+  env?: Record<string, string>;
+  stdin?: string;
+}
+
+type RunnableExecRequest = Required<Pick<ExecRequest, "source">> & Omit<ExecRequest, "source">;
+
+class CelldJavaScriptBackend implements WorkspaceModuleBackend {
+  readonly protocol = "module" as const;
+  readonly type = "celld-javascript";
+  readonly callable = true;
+  readonly id = "celld-javascript";
+
+  constructor(private readonly loader: WorkspaceRuntimeLoader) {}
+
+  async connect(_host: WorkspaceModuleBackendHost): Promise<WorkspaceModuleBackendHandle> {
+    return new CelldJavaScriptBackendHandle(this.loader, this.id);
+  }
+}
+
+class CelldJavaScriptBackendHandle implements WorkspaceModuleBackendHandle {
+  private readonly records = new Map<string, WorkspaceRuntimeEvent[]>();
+
+  constructor(
+    private readonly loader: WorkspaceRuntimeLoader,
+    private readonly backendId: string,
+  ) {}
+
+  async exec(input: ModuleExecutionInput): Promise<ModuleExecutionEnvelope> {
+    const id = input.id ?? crypto.randomUUID();
+    const events = await this.run(id, input);
+    this.records.set(id, events);
+    return { id, events: streamEvents(events) };
+  }
+
+  async getExec(input: { id: string; after?: number | "tail" }): Promise<ModuleExecutionEnvelope> {
+    const events = this.records.get(input.id);
+    if (!events) throw Object.assign(new Error(`no such execution: ${input.id}`), { code: "ENOENT" });
+    const after = input.after === "tail" ? Math.max(0, events.length - 1) : input.after ?? 0;
+    return { id: input.id, events: streamEvents(events.filter((event) => event.seq > after)) };
+  }
+
+  async killExec(_input: { id: string }): Promise<void> {
+    throw new Error(`${this.backendId} executions are synchronous and cannot be killed after admission.`);
+  }
+
+  async disposeExec(input: { id: string }): Promise<void> {
+    this.records.delete(input.id);
+  }
+
+  private async run(id: string, input: ModuleExecutionInput): Promise<WorkspaceRuntimeEvent[]> {
+    try {
+      const worker = this.loader.load({
+        compatibilityDate: "2026-05-26",
+        compatibilityFlags: ["nodejs_compat", "js_rpc"],
+        limits: { cpuMs: input.timeoutMs ?? 30_000 },
+        mainModule: "runner.js",
+        modules: {
+          "entry.js": input.source,
+          "runner.js": celldJavaScriptRunner(),
+        },
+        globalOutbound: null,
+      });
+      const entrypoint = worker.getEntrypoint("Runner", {
+        limits: { cpuMs: input.timeoutMs ?? 30_000 },
+      }) as {
+        evaluate(
+          input: WorkspaceRuntimeValue,
+          context: { env: Record<string, string>; cwd: string; stdin: string },
+        ): Promise<{ value: WorkspaceRuntimeValue; stdout: string; stderr: string }>;
+      };
+      const result = await entrypoint.evaluate(input.input ?? null, {
+        env: input.env ?? {},
+        cwd: input.cwd ?? MOUNT_ROOT,
+        stdin: typeof input.stdin === "string" ? input.stdin : decodeBytes(input.stdin),
+      });
+      const events: WorkspaceRuntimeEvent[] = [];
+      if (result.stdout) events.push({ id, seq: events.length + 1, name: "stdout", value: encode(result.stdout) });
+      if (result.stderr) events.push({ id, seq: events.length + 1, name: "stderr", value: encode(result.stderr) });
+      events.push({ id, seq: events.length + 1, name: "exit", code: 0, result: result.value ?? null });
+      return events;
+    } catch (error) {
+      return [
+        {
+          id,
+          seq: 1,
+          name: "stderr",
+          value: encode(`${error instanceof Error ? error.message : String(error)}\n`),
+        },
+        { id, seq: 2, name: "exit", code: 1 },
+      ];
+    }
+  }
+}
+
+interface AgentState {
+  requests: number;
+}
+
+export class FilesystemAgent extends Agent<Env, AgentState> {
+  initialState: AgentState = { requests: 0 };
+
+  async onRequest(request: Request): Promise<Response> {
+    const workspace = new Workspace({
+      storage: this.ctx.storage as unknown as DurableObjectStorageLike,
+      backends: [],
+    });
+    const tools = createAITools({ workspace, assets: false });
+    const url = new URL(request.url);
+    const nextState = { requests: (this.state.requests ?? 0) + 1 };
+    this.setState(nextState);
+
+    if (url.pathname.endsWith("/tools")) {
+      return json({
+        agent: "FilesystemAgent",
+        state: nextState,
+        tools: Object.keys(tools),
+        note: "Computer tools construct successfully inside an Agents SDK Agent on celld; runtime exec/publish are intentionally absent.",
+      });
+    }
+
+    if (request.method === "PUT" && url.pathname.endsWith("/file")) {
+      const path = resolveWorkspacePath(url.searchParams.get("path") ?? "");
+      if (path === null) return pathError(url.searchParams.get("path") ?? "");
+      await workspace.fs.mkdir(parentDirectory(path), { recursive: true });
+      await workspace.fs.writeFile(path, new Uint8Array(await request.arrayBuffer()));
+      return new Response(null, { status: 204 });
+    }
+
+    if (request.method === "GET" && url.pathname.endsWith("/file")) {
+      const path = resolveWorkspacePath(url.searchParams.get("path") ?? "");
+      if (path === null) return pathError(url.searchParams.get("path") ?? "");
+      try {
+        const stream = await workspace.fs.readFile(path, {});
+        return new Response(stream, { headers: { "content-type": "application/octet-stream" } });
+      } catch (error) {
+        return errorJSON(error, errorCode(error) === "ENOENT" ? 404 : 500);
+      }
+    }
+
+    return json({
+      agent: "FilesystemAgent",
+      state: nextState,
+      routes: ["GET ./tools", "PUT ./file?path=workspace/<path>", "GET ./file?path=workspace/<path>"],
+    });
+  }
 }
 
 interface CelldWorkspaceRpc {
@@ -49,12 +227,16 @@ interface CelldWorkspaceRpc {
   rm(path: string, options: { recursive?: boolean }): Promise<void>;
   readdir(path: string, limit: number): Promise<unknown>;
   mkdir(path: string): Promise<void>;
+  exec(request: RunnableExecRequest): Promise<unknown>;
 }
 
 const MOUNT_ROOT = "/workspace";
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    const agentResponse = await routeAgentRequest(request, env);
+    if (agentResponse) return agentResponse;
+
     const url = new URL(request.url);
 
     const fileMatch = url.pathname.match(/^\/fs\/(.+)$/);
@@ -76,6 +258,10 @@ export default {
       const path = resolveWorkspacePath(mkdirMatch[1]);
       if (path === null) return pathError(mkdirMatch[1]);
       return handleMkdir(request, env, cellName(url), path);
+    }
+
+    if (url.pathname === "/exec") {
+      return handleExec(request, env, cellName(url));
     }
 
     if (url.pathname === "/" || url.pathname === "") {
@@ -166,6 +352,29 @@ async function handleMkdir(
   }
 }
 
+async function handleExec(request: Request, env: Env, name: string): Promise<Response> {
+  if (request.method !== "POST") {
+    return new Response("method not allowed", { status: 405, headers: { allow: "POST" } });
+  }
+  if (!env.LOADER) {
+    return errorJSON(new Error("Dynamic Worker loader disabled; start celld with CELLD_WORKER_LOADER=LOADER"), 501);
+  }
+  let body: ExecRequest;
+  try {
+    body = (await request.json()) as ExecRequest;
+  } catch {
+    return errorJSON(new Error("invalid JSON body"), 400);
+  }
+  if (typeof body.source !== "string" || body.source.length === 0) {
+    return errorJSON(new Error("must provide source"), 400);
+  }
+  try {
+    return json(await workspaceStub(env, name).exec(body as RunnableExecRequest));
+  } catch (error) {
+    return errorJSON(error, 500);
+  }
+}
+
 function resolveWorkspacePath(rest: string): string | null {
   let decoded: string;
   try {
@@ -213,6 +422,60 @@ function errorJSON(error: unknown, status: number): Response {
   return json({ error: message, code: errorCode(error) }, status);
 }
 
+function encode(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function decodeBytes(value: Uint8Array | string | undefined): string {
+  if (value === undefined) return "";
+  return typeof value === "string" ? value : new TextDecoder().decode(value);
+}
+
+function streamEvents(events: WorkspaceRuntimeEvent[]): ReadableStream<WorkspaceRuntimeEvent> {
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) controller.enqueue(event);
+      controller.close();
+    },
+  });
+}
+
+function celldJavaScriptRunner(): string {
+  return `
+    import { WorkerEntrypoint } from "cloudflare:workers";
+    import * as userModule from "entry.js";
+
+    export class Runner extends WorkerEntrypoint {
+      async evaluate(input, context) {
+        const stdout = [];
+        const stderr = [];
+        const write = (target, args) => target.push(args.map(String).join(" ") + "\\n");
+        console.log = (...args) => write(stdout, args);
+        console.info = (...args) => write(stdout, args);
+        console.warn = (...args) => write(stderr, args);
+        console.error = (...args) => write(stderr, args);
+        globalThis.process = {
+          env: context.env || {},
+          argv: ["workspace", "entry.js"],
+          cwd: () => context.cwd || "/workspace",
+          platform: "linux",
+          stdin: context.stdin || "",
+          stdout: { write: (chunk) => { stdout.push(String(chunk)); return true; } },
+          stderr: { write: (chunk) => { stderr.push(String(chunk)); return true; } },
+        };
+        const result = typeof userModule.default === "function" ? await userModule.default(input) : userModule.default;
+        return { value: result ?? null, stdout: stdout.join(""), stderr: stderr.join("") };
+      }
+    }
+
+    export default {
+      fetch() {
+        return new Response("ok");
+      }
+    };
+  `;
+}
+
 async function collect(stream: ReadableStream<Uint8Array>): Promise<ArrayBuffer> {
   const chunks: Uint8Array[] = [];
   let size = 0;
@@ -247,7 +510,15 @@ function helpText(env: Env): string {
     `  GET    /ls/workspace/<dir>          list ${MOUNT_ROOT}/<dir>`,
     `  POST   /mkdir/workspace/<dir>       mkdir -p ${MOUNT_ROOT}/<dir>`,
     "",
-    "No runtime backend is configured; this example is filesystem-only.",
+    env.LOADER
+      ? "Dynamic Worker backend: POST /exec { source, input?, cwd?, env?, stdin? }"
+      : "Dynamic Worker backend disabled (set CELLD_WORKER_LOADER=LOADER before starting celld).",
+    "",
+    "Agents SDK smoke route:",
+    "  GET    /agents/filesystem-agent/<name>",
+    "  GET    /agents/filesystem-agent/<name>/tools",
+    "  PUT    /agents/filesystem-agent/<name>/file?path=workspace/<path>",
+    "  GET    /agents/filesystem-agent/<name>/file?path=workspace/<path>",
     "",
   ].join("\n");
 }

--- a/examples/celld/src/index.ts
+++ b/examples/celld/src/index.ts
@@ -4,18 +4,13 @@ import { Agent, routeAgentRequest } from "agents";
 import {
   type DurableObjectStorageLike,
   getWorkspace,
-  type ModuleExecutionEnvelope,
-  type ModuleExecutionInput,
   Workspace,
-  type WorkspaceModuleBackend,
-  type WorkspaceModuleBackendHandle,
-  type WorkspaceModuleBackendHost,
-  type WorkspaceRuntimeEvent,
-  type WorkspaceRuntimeLoader,
   type WorkspaceRuntimeValue,
   withWorkspace,
 } from "@cloudflare/computer";
 import { createAITools } from "@cloudflare/computer/tools";
+
+import { CELLD_JAVASCRIPT_BACKEND_ID, CelldJavaScriptBackend } from "./celld-javascript-backend";
 
 export class CelldWorkspace extends withWorkspace(class extends DurableObject<Env> {}, (self) => {
   const { ctx, env } = self as unknown as { ctx: DurableObjectState; env: Env };
@@ -59,7 +54,7 @@ export class CelldWorkspace extends withWorkspace(class extends DurableObject<En
   async exec(request: RunnableExecRequest): Promise<unknown> {
     const ws = await getWorkspace(this);
     const handle = await ws.runtime.exec(request.source, {
-      backend: "celld-javascript",
+      backend: CELLD_JAVASCRIPT_BACKEND_ID,
       cwd: request.cwd ?? MOUNT_ROOT,
       input: request.input,
       env: request.env,
@@ -79,94 +74,6 @@ interface ExecRequest {
 }
 
 type RunnableExecRequest = Required<Pick<ExecRequest, "source">> & Omit<ExecRequest, "source">;
-
-class CelldJavaScriptBackend implements WorkspaceModuleBackend {
-  readonly protocol = "module" as const;
-  readonly type = "celld-javascript";
-  readonly callable = true;
-  readonly id = "celld-javascript";
-
-  constructor(private readonly loader: WorkspaceRuntimeLoader) {}
-
-  async connect(_host: WorkspaceModuleBackendHost): Promise<WorkspaceModuleBackendHandle> {
-    return new CelldJavaScriptBackendHandle(this.loader, this.id);
-  }
-}
-
-class CelldJavaScriptBackendHandle implements WorkspaceModuleBackendHandle {
-  private readonly records = new Map<string, WorkspaceRuntimeEvent[]>();
-
-  constructor(
-    private readonly loader: WorkspaceRuntimeLoader,
-    private readonly backendId: string,
-  ) {}
-
-  async exec(input: ModuleExecutionInput): Promise<ModuleExecutionEnvelope> {
-    const id = input.id ?? crypto.randomUUID();
-    const events = await this.run(id, input);
-    this.records.set(id, events);
-    return { id, events: streamEvents(events) };
-  }
-
-  async getExec(input: { id: string; after?: number | "tail" }): Promise<ModuleExecutionEnvelope> {
-    const events = this.records.get(input.id);
-    if (!events) throw Object.assign(new Error(`no such execution: ${input.id}`), { code: "ENOENT" });
-    const after = input.after === "tail" ? Math.max(0, events.length - 1) : input.after ?? 0;
-    return { id: input.id, events: streamEvents(events.filter((event) => event.seq > after)) };
-  }
-
-  async killExec(_input: { id: string }): Promise<void> {
-    throw new Error(`${this.backendId} executions are synchronous and cannot be killed after admission.`);
-  }
-
-  async disposeExec(input: { id: string }): Promise<void> {
-    this.records.delete(input.id);
-  }
-
-  private async run(id: string, input: ModuleExecutionInput): Promise<WorkspaceRuntimeEvent[]> {
-    try {
-      const worker = this.loader.load({
-        compatibilityDate: "2026-05-26",
-        compatibilityFlags: ["nodejs_compat", "js_rpc"],
-        limits: { cpuMs: input.timeoutMs ?? 30_000 },
-        mainModule: "runner.js",
-        modules: {
-          "entry.js": input.source,
-          "runner.js": celldJavaScriptRunner(),
-        },
-        globalOutbound: null,
-      });
-      const entrypoint = worker.getEntrypoint("Runner", {
-        limits: { cpuMs: input.timeoutMs ?? 30_000 },
-      }) as {
-        evaluate(
-          input: WorkspaceRuntimeValue,
-          context: { env: Record<string, string>; cwd: string; stdin: string },
-        ): Promise<{ value: WorkspaceRuntimeValue; stdout: string; stderr: string }>;
-      };
-      const result = await entrypoint.evaluate(input.input ?? null, {
-        env: input.env ?? {},
-        cwd: input.cwd ?? MOUNT_ROOT,
-        stdin: typeof input.stdin === "string" ? input.stdin : decodeBytes(input.stdin),
-      });
-      const events: WorkspaceRuntimeEvent[] = [];
-      if (result.stdout) events.push({ id, seq: events.length + 1, name: "stdout", value: encode(result.stdout) });
-      if (result.stderr) events.push({ id, seq: events.length + 1, name: "stderr", value: encode(result.stderr) });
-      events.push({ id, seq: events.length + 1, name: "exit", code: 0, result: result.value ?? null });
-      return events;
-    } catch (error) {
-      return [
-        {
-          id,
-          seq: 1,
-          name: "stderr",
-          value: encode(`${error instanceof Error ? error.message : String(error)}\n`),
-        },
-        { id, seq: 2, name: "exit", code: 1 },
-      ];
-    }
-  }
-}
 
 interface AgentState {
   requests: number;
@@ -420,60 +327,6 @@ function errorCode(error: unknown): string | undefined {
 function errorJSON(error: unknown, status: number): Response {
   const message = error instanceof Error ? error.message : String(error);
   return json({ error: message, code: errorCode(error) }, status);
-}
-
-function encode(value: string): Uint8Array {
-  return new TextEncoder().encode(value);
-}
-
-function decodeBytes(value: Uint8Array | string | undefined): string {
-  if (value === undefined) return "";
-  return typeof value === "string" ? value : new TextDecoder().decode(value);
-}
-
-function streamEvents(events: WorkspaceRuntimeEvent[]): ReadableStream<WorkspaceRuntimeEvent> {
-  return new ReadableStream({
-    start(controller) {
-      for (const event of events) controller.enqueue(event);
-      controller.close();
-    },
-  });
-}
-
-function celldJavaScriptRunner(): string {
-  return `
-    import { WorkerEntrypoint } from "cloudflare:workers";
-    import * as userModule from "entry.js";
-
-    export class Runner extends WorkerEntrypoint {
-      async evaluate(input, context) {
-        const stdout = [];
-        const stderr = [];
-        const write = (target, args) => target.push(args.map(String).join(" ") + "\\n");
-        console.log = (...args) => write(stdout, args);
-        console.info = (...args) => write(stdout, args);
-        console.warn = (...args) => write(stderr, args);
-        console.error = (...args) => write(stderr, args);
-        globalThis.process = {
-          env: context.env || {},
-          argv: ["workspace", "entry.js"],
-          cwd: () => context.cwd || "/workspace",
-          platform: "linux",
-          stdin: context.stdin || "",
-          stdout: { write: (chunk) => { stdout.push(String(chunk)); return true; } },
-          stderr: { write: (chunk) => { stderr.push(String(chunk)); return true; } },
-        };
-        const result = typeof userModule.default === "function" ? await userModule.default(input) : userModule.default;
-        return { value: result ?? null, stdout: stdout.join(""), stderr: stderr.join("") };
-      }
-    }
-
-    export default {
-      fetch() {
-        return new Response("ok");
-      }
-    };
-  `;
 }
 
 async function collect(stream: ReadableStream<Uint8Array>): Promise<ArrayBuffer> {

--- a/examples/celld/src/index.ts
+++ b/examples/celld/src/index.ts
@@ -52,8 +52,19 @@ export class CelldAgent extends withWorkspace(CelldAgentBase, (self) => {
               defaultBackend: CELLD_JAVASCRIPT_BACKEND_ID,
               backends: {
                 [CELLD_JAVASCRIPT_BACKEND_ID]: {
-                  description:
-                    "A celld Dynamic Worker that runs an ECMAScript module with structured input and output. The loaded worker cannot access the workspace filesystem yet.",
+                  description: [
+                    "Runs a complete JavaScript module in a celld Dynamic Worker with structured input and output.",
+                    "Pass module source, not a filename or bare script. The module must have a default export. Export a function to receive `(input, ctx)` and return structured output.",
+                    "",
+                    "```js",
+                    "export default async function main(input, ctx) {",
+                    '  console.log("cwd:", ctx.cwd);',
+                    "  return { received: input };",
+                    "}",
+                    "```",
+                    "",
+                    "The loaded worker cannot access the Workspace filesystem. Use read, write, edit, ls, find, grep, and delete outside exec.",
+                  ].join("\n"),
                 },
               },
             },

--- a/examples/celld/tsconfig.json
+++ b/examples/celld/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["./worker-configuration.d.ts", "@cloudflare/workers-types"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["worker-configuration.d.ts", "src/**/*.ts"]
+}

--- a/examples/celld/worker-configuration.d.ts
+++ b/examples/celld/worker-configuration.d.ts
@@ -1,0 +1,7 @@
+import type { CelldWorkspace } from "./src/index";
+
+declare global {
+  interface Env {
+    WORKSPACE: DurableObjectNamespace<CelldWorkspace>;
+  }
+}

--- a/examples/celld/worker-configuration.d.ts
+++ b/examples/celld/worker-configuration.d.ts
@@ -1,7 +1,11 @@
-import type { CelldWorkspace } from "./src/index";
+import type { WorkspaceRuntimeLoader } from "@cloudflare/computer";
+import type { CelldWorkspace, FilesystemAgent } from "./src/index";
 
 declare global {
   interface Env {
     WORKSPACE: DurableObjectNamespace<CelldWorkspace>;
+    FilesystemAgent: DurableObjectNamespace<FilesystemAgent>;
+    // celld injects this binding when started with CELLD_WORKER_LOADER=LOADER.
+    LOADER?: WorkspaceRuntimeLoader;
   }
 }

--- a/examples/celld/worker-configuration.d.ts
+++ b/examples/celld/worker-configuration.d.ts
@@ -1,10 +1,11 @@
 import type { WorkspaceRuntimeLoader } from "@cloudflare/computer";
-import type { CelldWorkspace, FilesystemAgent } from "./src/index";
+import type { CelldAgent } from "./src/index";
 
 declare global {
   interface Env {
-    WORKSPACE: DurableObjectNamespace<CelldWorkspace>;
-    FilesystemAgent: DurableObjectNamespace<FilesystemAgent>;
+    CLOUDFLARE_ACCOUNT_ID: string;
+    CLOUDFLARE_API_TOKEN: string;
+    CelldAgent: DurableObjectNamespace<CelldAgent>;
     // celld injects this binding when started with CELLD_WORKER_LOADER=LOADER.
     LOADER?: WorkspaceRuntimeLoader;
   }

--- a/examples/celld/wrangler.jsonc
+++ b/examples/celld/wrangler.jsonc
@@ -10,12 +10,8 @@
   "durable_objects": {
     "bindings": [
       {
-        "name": "WORKSPACE",
-        "class_name": "CelldWorkspace"
-      },
-      {
-        "name": "FilesystemAgent",
-        "class_name": "FilesystemAgent"
+        "name": "CelldAgent",
+        "class_name": "CelldAgent"
       }
     ]
   },
@@ -23,7 +19,7 @@
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["CelldWorkspace", "FilesystemAgent"]
+      "new_sqlite_classes": ["CelldAgent"]
     }
   ]
 }

--- a/examples/celld/wrangler.jsonc
+++ b/examples/celld/wrangler.jsonc
@@ -1,7 +1,6 @@
 {
   // celld-compatible Wrangler project. celld intentionally accepts a small
-  // subset of Wrangler config, so the Dynamic Worker loader is enabled at
-  // runtime with CELLD_WORKER_LOADER=LOADER instead of a `worker_loaders` key.
+  // subset of Wrangler config; unsupported platform bindings are omitted.
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "computer-celld-example",
   "main": "src/index.ts",
@@ -13,6 +12,10 @@
       {
         "name": "WORKSPACE",
         "class_name": "CelldWorkspace"
+      },
+      {
+        "name": "FilesystemAgent",
+        "class_name": "FilesystemAgent"
       }
     ]
   },
@@ -20,7 +23,7 @@
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["CelldWorkspace"]
+      "new_sqlite_classes": ["CelldWorkspace", "FilesystemAgent"]
     }
   ]
 }

--- a/examples/celld/wrangler.jsonc
+++ b/examples/celld/wrangler.jsonc
@@ -1,0 +1,26 @@
+{
+  // celld-compatible Wrangler project. celld intentionally accepts a small
+  // subset of Wrangler config, so the Dynamic Worker loader is enabled at
+  // runtime with CELLD_WORKER_LOADER=LOADER instead of a `worker_loaders` key.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "computer-celld-example",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-05-26",
+  "compatibility_flags": ["nodejs_compat", "js_rpc"],
+
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "WORKSPACE",
+        "class_name": "CelldWorkspace"
+      }
+    ]
+  },
+
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["CelldWorkspace"]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,24 @@
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
+    "examples/celld": {
+      "name": "@example/computer-celld",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cloudflare/computer": "*"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260616.1",
+        "typescript": "^6.0.3"
+      }
+    },
+    "examples/celld/node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
     "examples/container": {
       "name": "@example/computer-container",
       "version": "0.0.0",
@@ -3110,6 +3128,10 @@
     },
     "node_modules/@example/computer-assets": {
       "resolved": "examples/assets",
+      "link": true
+    },
+    "node_modules/@example/computer-celld": {
+      "resolved": "examples/celld",
       "link": true
     },
     "node_modules/@example/computer-container": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,9 +66,17 @@
       "name": "@example/computer-celld",
       "version": "0.0.0",
       "dependencies": {
+        "@ai-sdk/react": "^4.0.45",
+        "@ai-sdk/tui": "^1.0.43",
+        "@cloudflare/ai-chat": "^0.10.1",
         "@cloudflare/computer": "*",
-        "agents": "^0.20.1",
-        "path": "^0.12.7"
+        "agents": "^0.20.0",
+        "ai": "^7.0.0",
+        "path": "^0.12.7",
+        "workers-ai-provider": "^4.0.0"
+      },
+      "bin": {
+        "celld-chat": "cli/chat.mjs"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260616.1",
@@ -1391,6 +1399,22 @@
         "fs-extra": "^7.0.1",
         "human-id": "^4.1.1",
         "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/@cloudflare/ai-chat": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.10.1.tgz",
+      "integrity": "sha512-kSycX0kJ93LbGCkA6j6w6nm0tieSE+MiC62EF3KyLWpsElUc0tHt7XcPs5Z300MvZU1oAoQWhRWcRK9pYHbDlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.16"
+      },
+      "peerDependencies": {
+        "@ai-sdk/react": "^3.0.0 || ^4.0.0",
+        "agents": ">=0.17.1 <1.0.0",
+        "ai": "^6.0.0 || ^7.0.0",
+        "react": "^19.0.0",
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@cloudflare/codemode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,9 @@
       "name": "@example/computer-celld",
       "version": "0.0.0",
       "dependencies": {
-        "@cloudflare/computer": "*"
+        "@cloudflare/computer": "*",
+        "agents": "^0.20.1",
+        "path": "^0.12.7"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260616.1",
@@ -10332,6 +10334,16 @@
         }
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12529,12 +12541,27 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "license": "ISC"
     },
     "node_modules/vary": {
       "version": "1.1.2",


### PR DESCRIPTION
`@cloudflare/computer` did not have an example showing how a Workspace and an Agents chat application run on celld. celld has no managed Workers AI binding, and its current Worker Loader cannot pass the Workspace filesystem capability into a loaded Worker, so existing Workers patterns do not run unchanged.

This adds a prototype centered on one `CelldAgent` durable object. `AIChatAgent` and `withWorkspace` share the same SQLite storage, `routeAgentRequest` exposes the standard Agents WebSocket route, and `createAITools()` gives the model the Workspace tools. The local harness starts an S3-compatible store, deploys the Worker, and enables celld's experimental Worker Loader. An AI SDK terminal client and a noninteractive smoke client use the same chat transport.

The model calls the Workers AI REST API with an account ID and API token. The callable `exec` backend runs complete JavaScript modules with structured input and output; its tool description shows the required default export. Filesystem work stays in the dedicated Workspace tools because the loaded Worker cannot access the Workspace mount.

To verify the example locally, install celld 0.1.0, then run:

```sh
npm install
npm run build --workspace @cloudflare/computer
export PATH="$PWD/node_modules/.bin:$HOME/.local/bin:$PATH"
export CLOUDFLARE_ACCOUNT_ID=<account-id>
export CLOUDFLARE_API_TOKEN=<api-token>
npm run dev:local --workspace @example/computer-celld
```

In another terminal, check the chat transport or open the interactive client:

```sh
npm run smoke --workspace @example/computer-celld
npm run chat --workspace @example/computer-celld
```

The change passes `npm run typecheck --workspace @example/computer-celld`, `npm run check`, and `celld deploy --dry-run`. It was also checked against a real celld server with Workers AI, Workspace reads and writes, and a default-exported module through `exec`.

The README covers installation, credentials, local startup, client options, storage, the `exec` contract, and backend limits. Filesystem access and live output inside the loaded Worker remain follow-up work until celld can pass the required capability into a Dynamic Worker.
