### PR TITLE
Make artifacts scope optional

### DIFF
--- a/.changeset/tall-pumas-shave.md
+++ b/.changeset/tall-pumas-shave.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/computer": minor
+---
+
+Make the artifacts session id optional. `createArtifact(binding)` now returns a client over the whole namespace: names are the ones the binding stores, `list()` returns every repository including those sessions own, and each one can be read, written to, or deleted under its stored name. A `Workspace` with an Artifacts binding and no session id gets that client instead of throwing from its constructor, and `artifacts: { binding, sessionId: null }` asks for it explicitly. Passing a session id behaves as before. `ArtifactClient.sessionId` is now `string | undefined`.

--- a/.changeset/tall-pumas-shave.md
+++ b/.changeset/tall-pumas-shave.md
@@ -2,4 +2,4 @@
 "@cloudflare/computer": minor
 ---
 
-Make the artifacts session id optional. `createArtifact(binding)` now returns a client over the whole namespace: names are the ones the binding stores, `list()` returns every repository including those sessions own, and each one can be read, written to, or deleted under its stored name. A `Workspace` with an Artifacts binding and no session id gets that client instead of throwing from its constructor, and `artifacts: { binding, sessionId: null }` asks for it explicitly. Passing a session id behaves as before. `ArtifactClient.sessionId` is now `string | undefined`.
+Make the artifacts session id optional: `createArtifact(binding)` now returns a client over the whole namespace rather than requiring a session to scope by. See [./docs/15_artifacts_interface.md](./docs/15_artifacts_interface.md) for details.

--- a/docs/01_vfs.md
+++ b/docs/01_vfs.md
@@ -36,7 +36,7 @@ Workspace where `fs` works against the local SQLite store but
 `WorkspaceOptions` includes the storage handle, optional backends,
 clock, session id, mounts, observer, git identity, assets, artifacts,
 and `useThink`. There is no `root` or `sandbox` field on the host
-facade — sandbox wiring lives behind a `WorkspaceBackend`.
+wrapper — sandbox wiring lives behind a `WorkspaceBackend`.
 
 Set `useThink: true` when assigning the Workspace to
 `Think.workspace`. This adds Think's string-oriented filesystem

--- a/docs/02_sync_protocol.md
+++ b/docs/02_sync_protocol.md
@@ -292,7 +292,7 @@ edited file) shows up exactly once on the wire. See
   go through a per-Workspace tail-promise FIFO. Two concurrent
   callers queue — the second can't enter `pushOnce` / `pullOnce`
   until the first has resolved or rejected. A command's pre-exec push
-  and post-stream pull each use this facade, but the FIFO is not held
+  and post-stream pull each use this wrapper, but the FIFO is not held
   for the command's lifetime: overlapping commands and explicit sync
   calls are not one transaction. Rejections aren't contagious: a
   failed mutation surfaces its error to its own caller without

--- a/docs/10_project_layout.md
+++ b/docs/10_project_layout.md
@@ -16,7 +16,7 @@ The workspace ships as a monorepo. Each published package lives under
 ```
 computer/
 ├── packages/
-│   ├── computer/                       # @cloudflare/computer — DO-side facade, backends, proxy
+│   ├── computer/                       # @cloudflare/computer — DO-side wrapper, backends, proxy
 │   ├── dofs/                           # @cloudflare/dofs — SQLite-backed VFS + sync
 │   ├── rpc/                            # @cloudflare/computer-rpc — capnweb wire interface
 │   ├── computerd/                      # @cloudflare/computerd — in-container daemon (binary)
@@ -40,7 +40,7 @@ they refer to the same code under the new names.
 
 ## `packages/computer/` — `@cloudflare/computer`
 
-The DO-side facade. Owns the `Workspace` class, re-exports
+The DO-side wrapper. Owns the `Workspace` class, re-exports
 `WorkspaceFilesystem` from `@cloudflare/dofs`, exposes the public
 `WorkspaceRuntime` surface, and routes execution across command and
 module backends. It also ships the `WorkspaceProxy` used by clients
@@ -50,7 +50,7 @@ that talk to a workspace through an RPC stub.
 packages/computer/
 ├── src/
 │   ├── index.ts                     # Public entrypoint
-│   ├── workspace.ts                 # Workspace facade
+│   ├── workspace.ts                 # Workspace wrapper
 │   ├── runtime/                     # Public runtime router and capabilities
 │   ├── shell.ts                     # Internal command-backend adapter
 │   ├── backend.ts                   # Command backend interface
@@ -72,7 +72,7 @@ packages/computer/
 └── package.json
 ```
 
-The package builds ESM and declarations with Rolldown. Public entrypoints include the root facade, tools, Git, assets, artifacts, the Container, Worker shell, and Worker JavaScript backends, and Cloudflare observability. The injected service is the separate `computerd` package, and shared wire types live in `@cloudflare/computer-rpc`.
+The package builds ESM and declarations with Rolldown. Public entrypoints include the root export, tools, Git, assets, artifacts, the Container, Worker shell, and Worker JavaScript backends, and Cloudflare observability. The injected service is the separate `computerd` package, and shared wire types live in `@cloudflare/computer-rpc`.
 
 ## `packages/dofs/` — `@cloudflare/dofs`
 

--- a/docs/15_artifacts_interface.md
+++ b/docs/15_artifacts_interface.md
@@ -11,11 +11,9 @@ through a namespace binding (`env.ARTIFACTS`) that can create,
 inspect, import, and delete repositories and mint Git tokens scoped
 to a repository.
 
-`@cloudflare/computer/artifacts` wraps that binding with a facade
-that is session-scoped when you ask for it.
-`createArtifact(binding, sessionId)` binds a namespace binding and a
-session id once and returns a client whose every operation is
-implicitly scoped to that session.
+`@cloudflare/computer/artifacts` wraps that binding with optional
+session scoping. `createArtifact(binding, sessionId)` returns a
+client whose every operation is implicitly scoped to that session.
 
 ```ts
 import { createArtifact } from "@cloudflare/computer/artifacts";
@@ -91,11 +89,9 @@ a repository a session created. Give a session id to any client
 that represents one tenant, and leave it off only for a caller that
 administers the namespace.
 
-Absence has to be spelled out. Only an omitted or `null` session id
-means "no session"; an empty string is still an
-`InvalidSessionIdError`, so an id that came out empty by accident
-fails loudly instead of quietly widening the client to every
-session.
+Only an omitted or `null` session id means "no session"; an empty
+string is still an `InvalidSessionIdError`, so an accidentally empty
+id fails instead of silently widening the client.
 
 ## Two doors into the same implementation
 

--- a/docs/15_artifacts_interface.md
+++ b/docs/15_artifacts_interface.md
@@ -313,6 +313,12 @@ explicit `artifacts: { binding, sessionId: null }`, the opt-out for
 a workspace that has a session id but wants artifacts across every
 session — `workspace.artifacts` spans the namespace.
 
+An empty session id fails here the same way it fails at
+`createArtifact`: the constructor throws `InvalidSessionIdError`.
+A workspace whose session id comes from an unset variable or a
+missing request field stops rather than handing that tenant a
+client over every other tenant's repositories.
+
 When `artifacts` is omitted from `Workspace`, the command still
 exists, but operations fail with a clear "Workspace Artifacts binding
 is not configured" error.

--- a/docs/15_artifacts_interface.md
+++ b/docs/15_artifacts_interface.md
@@ -344,7 +344,7 @@ The binding and its wire shapes are the global types from
 `ArtifactsRepo` (the repo handle), `ArtifactsCreateRepoResult`,
 `ArtifactsRepoInfo`, `ArtifactsTokenInfo`, `ArtifactsError`, and so
 on. `createArtifact(binding, sessionId?)` takes an `Artifacts` and
-returns metadata in those same shapes — the facade adds session
+returns metadata in those same shapes — the wrapper adds session
 scoping, it does not redeclare the protocol. Workers consumers get
 the globals from their own `@cloudflare/workers-types` setup, and
 this package's typecheck uses the same source of truth.
@@ -354,5 +354,5 @@ The in-memory `FakeArtifactsBinding` the tests run against
 real interface; a drift in the published shape fails the build
 rather than passing green.
 
-The facade covers the repository and token lifecycle. The binding's
+The wrapper covers the repository and token lifecycle. The binding's
 `fork` is intentionally out of scope for now.

--- a/docs/15_artifacts_interface.md
+++ b/docs/15_artifacts_interface.md
@@ -256,11 +256,11 @@ shared link does not disturb others.
 
 Help is a first-class, agent-readable surface. `help`, `--help`,
 `-h`, and each group's `--help` print documentation that spells out
-the secret-handling rules and whichever naming contract the client
-actually applies: local names under a session, stored names and a
-namespace-wide `repo list` without one. A bare `artifacts` prints
-the top-level help and exits non-zero, the way `git` with no args
-does.
+the secret-handling rules and the client's actual state: local names
+under a session, stored names and a namespace-wide `repo list`
+without one, or a clear configuration notice when no binding is
+available. A bare `artifacts` prints the top-level help and exits
+non-zero, the way `git` with no args does.
 
 ### Exit codes
 
@@ -322,7 +322,8 @@ quietly widening that tenant's access.
 
 When `artifacts` is omitted from `Workspace`, the command still
 exists, but operations fail with a clear "Workspace Artifacts binding
-is not configured" error.
+is not configured" error. Its help prints the same notice instead of
+describing session or namespace access that is not available.
 
 The binding stanza in the consumer's Wrangler config:
 

--- a/docs/15_artifacts_interface.md
+++ b/docs/15_artifacts_interface.md
@@ -11,10 +11,11 @@ through a namespace binding (`env.ARTIFACTS`) that can create,
 inspect, import, and delete repositories and mint Git tokens scoped
 to a repository.
 
-`@cloudflare/computer/artifacts` wraps that binding with a
-**session-scoped** facade. `createArtifact(binding, sessionId)`
-binds a namespace binding and a session id once and returns a client
-whose every operation is implicitly scoped to that session.
+`@cloudflare/computer/artifacts` wraps that binding with a facade
+that is session-scoped when you ask for it.
+`createArtifact(binding, sessionId)` binds a namespace binding and a
+session id once and returns a client whose every operation is
+implicitly scoped to that session.
 
 ```ts
 import { createArtifact } from "@cloudflare/computer/artifacts";
@@ -28,6 +29,10 @@ const repo = await artifacts.create("build-cache", {
 // repo.remote  -> "https://.../<agentId>__build-cache.git"
 // repo.token   -> initial git token (a secret)
 ```
+
+The session id is optional. `createArtifact(binding)` returns a
+client over the namespace as a whole — see
+[without a session id](#without-a-session-id).
 
 ## Session scoping
 
@@ -57,6 +62,41 @@ This lets one namespace host many isolated sessions — one per agent,
 user, or task — without the caller managing prefixes by hand, and
 without one session enumerating or colliding with another's repos.
 
+## Without a session id
+
+`createArtifact(binding)` builds a client with no session at all.
+Nothing is prefixed on the way in, nothing is stripped or filtered
+on the way out, and the names it works in are the ones the
+namespace stores.
+
+```ts
+const artifacts = createArtifact(env.ARTIFACTS);
+
+artifacts.sessionId;                   // undefined
+await artifacts.list();                // every repo in the namespace
+await artifacts.get("agent-7__build-cache");   // another session's repo
+await artifacts.create("shared-cache");        // stored as "shared-cache"
+```
+
+A name here may carry the scope separator, because the repositories
+a session owns are stored under `<session>__<name>` and reaching
+them is the point. Names are still held to the binding's charset,
+so `assertRepoName` rejects the same empty and `/`-bearing names it
+always did.
+
+The reach covers writes as well as reads: `create`,
+`import`, `delete`, and the token methods all take the stored name
+literally, so an unscoped client can mint a token for, or delete,
+a repository a session created. Give a session id to any client
+that represents one tenant, and leave it off only for a caller that
+administers the namespace.
+
+Absence has to be spelled out. Only an omitted or `null` session id
+means "no session"; an empty string is still an
+`InvalidSessionIdError`, so an id that came out empty by accident
+fails loudly instead of quietly widening the client to every
+session.
+
 ## Two doors into the same implementation
 
 Like `workspace.git`, the artifacts surface has a typed API and an
@@ -80,13 +120,16 @@ parts they share.
 
 ## Typed surface
 
-`createArtifact(binding, sessionId)` returns an `ArtifactClient`:
+`createArtifact(binding, sessionId?)` returns an `ArtifactClient`.
+The table describes a client with a session id; without one, every
+row reads the same with "the session's" replaced by "the
+namespace's" and "local name" by "stored name":
 
 | Method | Purpose |
 | --- | --- |
 | `create(name, opts?)` | Create a repo. Returns `{ name, remote, defaultBranch, token }` with a local `name`. |
 | `get(name)` | Resolve full `ArtifactsRepoInfo` metadata with a local `name`. Throws if missing. |
-| `list()` | The session's repo summaries: `Omit<ArtifactsRepoInfo, "remote">[]`, each with a local `name`. Walks every page. |
+| `list()` | The session's repo summaries: `Omit<ArtifactsRepoInfo, "remote">[]`, each with a local `name`. Walks every page. Unscoped, this is the whole namespace. |
 | `import(name, source, opts?)` | Import an external git remote into a session repo. |
 | `delete(name)` | Delete a repo. Returns `false` when it does not exist. |
 | `createToken(name, scope?, ttl?)` | Mint a git token. Returns `{ id, plaintext, scope, expiresAt }`. |
@@ -94,6 +137,9 @@ parts they share.
 | `getToken(name, id)` | One token's metadata from that page. Throws `NotFoundError` on a miss. |
 | `revokeToken(name, tokenOrId)` | Revoke a token. Returns `false` on a miss. |
 | `cli(input)` | The argv door (below). `input` may also carry a `remoteAdd` seam used only by the CLI `create` shorthand. |
+
+`sessionId` on the client is the session it is scoped to, or
+`undefined` when it spans the namespace.
 
 `opts` for `create` carries `description`, `readOnly`, and
 `setDefaultBranch`. `source` for `import` carries `url`, `branch`,
@@ -103,8 +149,14 @@ is `"read"` or `"write"` (default `"write"`); `ttl` is in seconds.
 ### Pagination
 
 `list()` exposes no cursor. It walks the binding's pages internally
-until they are exhausted and returns the full session-scoped set. The
-page size is an internal constant, not a caller-facing cap.
+until they are exhausted and returns the full set: the session's
+repositories under a session id, every repository in the namespace
+without one. The page size is an internal constant, not a
+caller-facing cap.
+
+With a session id the walk also does the filtering, so a namespace
+shared by many sessions costs the same number of round trips either
+way.
 
 ### `getToken` and the binding
 
@@ -208,9 +260,11 @@ shared link does not disturb others.
 
 Help is a first-class, agent-readable surface. `help`, `--help`,
 `-h`, and each group's `--help` print documentation that spells out
-the session-scoping contract and the secret-handling rules. A bare
-`artifacts` prints the top-level help and exits non-zero, the way
-`git` with no args does.
+the secret-handling rules and whichever naming contract the client
+actually applies: local names under a session, stored names and a
+namespace-wide `repo list` without one. A bare `artifacts` prints
+the top-level help and exits non-zero, the way `git` with no args
+does.
 
 ### Exit codes
 
@@ -256,6 +310,13 @@ export class MyAgent extends DurableObject<Env> {
 }
 ```
 
+The client is scoped to a session when one is available. The session
+id defaults to `WorkspaceOptions.sessionId`, and
+`artifacts.sessionId` overrides it. With neither — or with an
+explicit `artifacts: { binding, sessionId: null }`, the opt-out for
+a workspace that has a session id but wants artifacts across every
+session — `workspace.artifacts` spans the namespace.
+
 When `artifacts` is omitted from `Workspace`, the command still
 exists, but operations fail with a clear "Workspace Artifacts binding
 is not configured" error.
@@ -286,7 +347,7 @@ The binding and its wire shapes are the global types from
 `@cloudflare/workers-types`: `Artifacts` (the namespace binding),
 `ArtifactsRepo` (the repo handle), `ArtifactsCreateRepoResult`,
 `ArtifactsRepoInfo`, `ArtifactsTokenInfo`, `ArtifactsError`, and so
-on. `createArtifact(binding, sessionId)` takes an `Artifacts` and
+on. `createArtifact(binding, sessionId?)` takes an `Artifacts` and
 returns metadata in those same shapes — the facade adds session
 scoping, it does not redeclare the protocol. Workers consumers get
 the globals from their own `@cloudflare/workers-types` setup, and

--- a/docs/15_artifacts_interface.md
+++ b/docs/15_artifacts_interface.md
@@ -313,11 +313,12 @@ explicit `artifacts: { binding, sessionId: null }`, the opt-out for
 a workspace that has a session id but wants artifacts across every
 session — `workspace.artifacts` spans the namespace.
 
-An empty session id fails here the same way it fails at
-`createArtifact`: the constructor throws `InvalidSessionIdError`.
-A workspace whose session id comes from an unset variable or a
-missing request field stops rather than handing that tenant a
-client over every other tenant's repositories.
+An omitted or undefined session id intentionally gives the
+workspace access to the whole namespace. An empty string is
+different: the constructor throws `InvalidSessionIdError`. This
+catches blank input and code that normalizes a missing value to
+`""`, such as `sessionId: request.sessionId ?? ""`, rather than
+quietly widening that tenant's access.
 
 When `artifacts` is omitted from `Workspace`, the command still
 exists, but operations fail with a clear "Workspace Artifacts binding

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,12 +42,12 @@ The package ships several entrypoints:
 
 | Entrypoint | Purpose |
 | --- | --- |
-| `@cloudflare/computer` | The Workspace facade, first-class `workspace.runtime`, stub types, the R2 mount, and proxy classes. |
+| `@cloudflare/computer` | The Workspace wrapper, first-class `workspace.runtime`, stub types, the R2 mount, and proxy classes. |
 | `@cloudflare/computer/backends/container` | `CloudflareContainerBackend` and `withWorkspaceContainer`. Pulls in the computerd / capnweb sync plumbing. |
 | `@cloudflare/computer/backends/worker-shell` | `WorkerShellBackend` and the bundled just-bash command runtime. |
 | `@cloudflare/computer/backends/worker-javascript` | `WorkerJavaScriptBackend`, configured libraries, durable relative imports, `node:fs/promises`, and trusted `ws:git` / `ws:artifacts`. |
 | `@cloudflare/computer/git` | Opt-in isomorphic-git glue for working with checkouts inside the workspace. Bundled lazily, with `pako` replaced by Workers `node:zlib`, and kept out of the default `@cloudflare/computer` graph. |
-| `@cloudflare/computer/artifacts` | `createArtifact`, an optionally session-scoped facade over the Cloudflare Artifacts Workers binding, plus its argv CLI. |
+| `@cloudflare/computer/artifacts` | `createArtifact`, an optionally session-scoped wrapper over the Cloudflare Artifacts Workers binding, plus its argv CLI. |
 | `@cloudflare/computer/tools` | AI SDK tools for agents: read, write, edit, ls, optional exec, and optional publish. |
 
 A consumer that only uses the container backend never imports the
@@ -238,7 +238,7 @@ above, then dive into the area you're working on.
 | [12. Worker backend](./12_worker_backend.md) | Running the shell as just-bash inside a Dynamic Worker loaded through `env.LOADER`. |
 | [13. Git interface](./13_git_interface.md) | `workspace.git` and the `git` CLI inside the shell, backed by isomorphic-git. |
 | [14. Assets interface](./14_assets_interface.md) | `share` a workspace file to R2 and get back a presigned URL. |
-| [15. Artifacts interface](./15_artifacts_interface.md) | `createArtifact` and the `artifacts` CLI, an optionally session-scoped facade over the Cloudflare Artifacts binding. |
+| [15. Artifacts interface](./15_artifacts_interface.md) | `createArtifact` and the `artifacts` CLI, an optionally session-scoped wrapper over the Cloudflare Artifacts binding. |
 | [16. Execution runtime architecture](./16_code_execution.md) | One runtime entry point over command and module backends. |
 | [17. Isolate JavaScript runtime](./17_isolate_javascript.md) | ECMAScript modules, durable imports, configured libraries, durable `node:fs/promises`, trusted `ws:git` / `ws:artifacts`, and managed lifecycle. |
 | [18. Runtime migration](./18_runtime_migration.md) | Breaking preview-API mappings from public shell and script-execution surfaces to `workspace.runtime`. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ The package ships several entrypoints:
 | `@cloudflare/computer/backends/worker-shell` | `WorkerShellBackend` and the bundled just-bash command runtime. |
 | `@cloudflare/computer/backends/worker-javascript` | `WorkerJavaScriptBackend`, configured libraries, durable relative imports, `node:fs/promises`, and trusted `ws:git` / `ws:artifacts`. |
 | `@cloudflare/computer/git` | Opt-in isomorphic-git glue for working with checkouts inside the workspace. Bundled lazily, with `pako` replaced by Workers `node:zlib`, and kept out of the default `@cloudflare/computer` graph. |
-| `@cloudflare/computer/artifacts` | `createArtifact`, a session-scoped facade over the Cloudflare Artifacts Workers binding, plus its argv CLI. |
+| `@cloudflare/computer/artifacts` | `createArtifact`, an optionally session-scoped facade over the Cloudflare Artifacts Workers binding, plus its argv CLI. |
 | `@cloudflare/computer/tools` | AI SDK tools for agents: read, write, edit, ls, optional exec, and optional publish. |
 
 A consumer that only uses the container backend never imports the
@@ -238,7 +238,7 @@ above, then dive into the area you're working on.
 | [12. Worker backend](./12_worker_backend.md) | Running the shell as just-bash inside a Dynamic Worker loaded through `env.LOADER`. |
 | [13. Git interface](./13_git_interface.md) | `workspace.git` and the `git` CLI inside the shell, backed by isomorphic-git. |
 | [14. Assets interface](./14_assets_interface.md) | `share` a workspace file to R2 and get back a presigned URL. |
-| [15. Artifacts interface](./15_artifacts_interface.md) | `createArtifact` and the `artifacts` CLI, a session-scoped facade over the Cloudflare Artifacts binding. |
+| [15. Artifacts interface](./15_artifacts_interface.md) | `createArtifact` and the `artifacts` CLI, an optionally session-scoped facade over the Cloudflare Artifacts binding. |
 | [16. Execution runtime architecture](./16_code_execution.md) | One runtime entry point over command and module backends. |
 | [17. Isolate JavaScript runtime](./17_isolate_javascript.md) | ECMAScript modules, durable imports, configured libraries, durable `node:fs/promises`, trusted `ws:git` / `ws:artifacts`, and managed lifecycle. |
 | [18. Runtime migration](./18_runtime_migration.md) | Breaking preview-API mappings from public shell and script-execution surfaces to `workspace.runtime`. |

--- a/examples/container/src/index.ts
+++ b/examples/container/src/index.ts
@@ -78,7 +78,7 @@ function workspaceOptions(self: InstanceType<typeof ContainerBase>): WorkspaceOp
     },
     // Route every workspace operation through the Cloudflare
     // runtime's user-tracing surface. The runtime owns the span
-    // lifecycle; the observer is a thin facade that forwards seed
+    // lifecycle; the observer is a thin wrapper that forwards seed
     // attributes and a `setAttribute` callback. With
     // `observability.traces.enabled = true` in wrangler.jsonc, the
     // spans show up in the Workers Observability dashboard

--- a/packages/computer/README.md
+++ b/packages/computer/README.md
@@ -341,10 +341,12 @@ Two ways to get a file out of the workspace and into the world:
   `assets publish <path> [<expiry>]` command. See
   [`docs/14_assets_interface.md`](../../docs/14_assets_interface.md).
 - **Artifacts** (`@cloudflare/computer/artifacts`):
-  `createArtifact(binding, sessionId)` is a session-scoped facade over
+  `createArtifact(binding, sessionId)` is a facade over
   the [Cloudflare Artifacts](https://developers.cloudflare.com/artifacts/)
   binding. Every repository name is implicitly prefixed with the session
-  id, so one namespace hosts many isolated sessions.
+  id, so one namespace hosts many isolated sessions. The session id is
+  optional: leave it off and the client spans the namespace, listing and
+  reaching every repository including those other sessions own.
 
 ```ts
 import { createArtifact } from "@cloudflare/computer/artifacts";
@@ -353,6 +355,9 @@ const artifacts = createArtifact(env.ARTIFACTS, agentId);
 const repo = await artifacts.create("build-cache", { description: "CI artifacts" });
 const token = await artifacts.createToken("build-cache", "read", 3600);
 const mine = await artifacts.list(); // only this session's repos
+
+const all = createArtifact(env.ARTIFACTS);
+await all.list(); // every repo in the namespace, under its stored name
 ```
 
 Artifacts also offers an argv CLI (`artifacts.cli({ argv })`), and when
@@ -414,7 +419,7 @@ on a computerd instance.
 | `@cloudflare/computer/tools` | AI SDK tools for agents: `read`, `ls`, `find`, `grep`, `write`, `edit`, `delete`, and optional `exec` and `publish`. |
 | `@cloudflare/computer/git` | Opt-in `isomorphic-git` glue for checkouts inside the workspace. |
 | `@cloudflare/computer/assets` | `createAssets` — share a workspace file to R2 as a presigned URL. |
-| `@cloudflare/computer/artifacts` | `createArtifact` and its CLI, a session-scoped facade over the Cloudflare Artifacts binding. |
+| `@cloudflare/computer/artifacts` | `createArtifact` and its CLI, an optionally session-scoped facade over the Cloudflare Artifacts binding. |
 | `@cloudflare/computer/observe/cloudflare` | Cloudflare-runtime adapter for the observability hook. |
 
 A consumer that only uses the container backend never imports the worker

--- a/packages/computer/README.md
+++ b/packages/computer/README.md
@@ -341,7 +341,7 @@ Two ways to get a file out of the workspace and into the world:
   `assets publish <path> [<expiry>]` command. See
   [`docs/14_assets_interface.md`](../../docs/14_assets_interface.md).
 - **Artifacts** (`@cloudflare/computer/artifacts`):
-  `createArtifact(binding, sessionId)` is a facade over
+  `createArtifact(binding, sessionId)` is a wrapper over
   the [Cloudflare Artifacts](https://developers.cloudflare.com/artifacts/)
   binding. Every repository name is implicitly prefixed with the session
   id, so one namespace hosts many isolated sessions. The session id is
@@ -412,14 +412,14 @@ on a computerd instance.
 
 | Entrypoint | Purpose |
 | --- | --- |
-| `@cloudflare/computer` | The `Workspace` facade, `workspace.runtime`, stub types, the R2 mount, and proxy classes. |
+| `@cloudflare/computer` | The `Workspace` wrapper, `workspace.runtime`, stub types, the R2 mount, and proxy classes. |
 | `@cloudflare/computer/backends/container` | `CloudflareContainerBackend` and `withWorkspaceContainer`. Pulls in the computerd / capnweb sync plumbing. |
 | `@cloudflare/computer/backends/worker-shell` | `WorkerShellBackend` and the bundled just-bash runtime. |
 | `@cloudflare/computer/backends/worker-javascript` | `WorkerJavaScriptBackend`, configured libraries, durable imports, `node:fs/promises`, and trusted `ws:git` / `ws:artifacts`. |
 | `@cloudflare/computer/tools` | AI SDK tools for agents: `read`, `ls`, `find`, `grep`, `write`, `edit`, `delete`, and optional `exec` and `publish`. |
 | `@cloudflare/computer/git` | Opt-in `isomorphic-git` glue for checkouts inside the workspace. |
 | `@cloudflare/computer/assets` | `createAssets` — share a workspace file to R2 as a presigned URL. |
-| `@cloudflare/computer/artifacts` | `createArtifact` and its CLI, an optionally session-scoped facade over the Cloudflare Artifacts binding. |
+| `@cloudflare/computer/artifacts` | `createArtifact` and its CLI, an optionally session-scoped wrapper over the Cloudflare Artifacts binding. |
 | `@cloudflare/computer/observe/cloudflare` | Cloudflare-runtime adapter for the observability hook. |
 
 A consumer that only uses the container backend never imports the worker

--- a/packages/computer/src/artifacts/cli.test.ts
+++ b/packages/computer/src/artifacts/cli.test.ts
@@ -98,6 +98,26 @@ describe("runArtifactsCLI", () => {
       const res = await client.cli({ argv: ["help"] });
       expect(res.stdout.toLowerCase()).toContain("session");
     });
+
+    it("tells an unscoped caller that names are namespace-wide", async () => {
+      // Help is the contract a shell consumer reads. Promising a
+      // session prefix that is not being applied would be worse than
+      // saying nothing.
+      const res = await createArtifact(binding).cli({ argv: ["help"] });
+      expect(res.stdout).toContain("not scoped to a session");
+      expect(res.stdout).toContain("every repository in the namespace");
+      expect(res.stdout).not.toContain("implicitly scoped");
+    });
+
+    it("drops the session-scoping line from group help when unscoped", async () => {
+      const unscoped = createArtifact(binding);
+      const repo = await unscoped.cli({ argv: ["repo", "--help"] });
+      const token = await unscoped.cli({ argv: ["token", "--help"] });
+      expect(repo.stdout).not.toContain("session-scoped");
+      expect(token.stdout).not.toContain("session-scoped");
+      expect(repo.stdout).toContain("repo create");
+      expect(token.stdout).toContain("token create");
+    });
   });
 
   describe("unknown commands", () => {
@@ -178,6 +198,15 @@ describe("runArtifactsCLI", () => {
       const res = await client.cli({ argv: ["repo", "list"] });
       expect(res.exitCode).toBe(0);
       expect(JSON.parse(res.stdout)).toEqual([]);
+    });
+
+    it("prints every repository in the namespace when unscoped", async () => {
+      await client.cli({ argv: ["repo", "create", "alpha"] });
+      const res = await createArtifact(binding).cli({ argv: ["repo", "list"] });
+      expect(res.exitCode).toBe(0);
+      expect(JSON.parse(res.stdout).map((r: { name: string }) => r.name)).toEqual([
+        "sess1__alpha",
+      ]);
     });
   });
 

--- a/packages/computer/src/artifacts/cli.test.ts
+++ b/packages/computer/src/artifacts/cli.test.ts
@@ -204,9 +204,7 @@ describe("runArtifactsCLI", () => {
       await client.cli({ argv: ["repo", "create", "alpha"] });
       const res = await createArtifact(binding).cli({ argv: ["repo", "list"] });
       expect(res.exitCode).toBe(0);
-      expect(JSON.parse(res.stdout).map((r: { name: string }) => r.name)).toEqual([
-        "sess1__alpha",
-      ]);
+      expect(JSON.parse(res.stdout).map((r: { name: string }) => r.name)).toEqual(["sess1__alpha"]);
     });
   });
 

--- a/packages/computer/src/artifacts/cli.ts
+++ b/packages/computer/src/artifacts/cli.ts
@@ -15,7 +15,7 @@
 
 import type { ArtifactClient } from "./client.js";
 import { parseDuration } from "./duration.js";
-import { ArtifactError } from "./errors.js";
+import { ARTIFACTS_NOT_CONFIGURED_MESSAGE, ArtifactError } from "./errors.js";
 import type { ArtifactScope } from "./types.js";
 
 /**
@@ -58,31 +58,35 @@ export interface ArtifactsCLIResult {
 export async function runArtifactsCLI(
   client: ArtifactClient,
   input: ArtifactsCLIInput,
+  bindingConfigured = true,
 ): Promise<ArtifactsCLIResult> {
   const argv = input.argv;
-  // Help describes the scoping the client actually applies, so every
-  // help path is told whether this client sits in one session or
-  // spans the namespace.
-  const scoped = client.sessionId !== undefined;
+  // Help describes the state the client actually runs in: one
+  // session, the whole namespace, or no binding at all.
+  const mode: ArtifactsHelpMode = bindingConfigured
+    ? client.sessionId === undefined
+      ? "namespace"
+      : "session"
+    : "unconfigured";
   if (argv.length === 0) {
     // Bare invocation: print help but signal misuse, the way `git`
     // with no args exits non-zero.
-    return { stdout: topLevelHelp(scoped), stderr: "", exitCode: 1 };
+    return { stdout: topLevelHelp(mode), stderr: "", exitCode: 1 };
   }
   const [group, ...rest] = argv;
   switch (group) {
     case "help":
     case "--help":
     case "-h":
-      return ok(topLevelHelp(scoped));
+      return ok(topLevelHelp(mode));
     case "create":
       return await runCreate(client, rest, input.remoteAdd);
     case "share":
       return await runShare(client, rest);
     case "repo":
-      return await runRepo(client, rest, scoped);
+      return await runRepo(client, rest, mode);
     case "token":
-      return await runToken(client, rest, scoped);
+      return await runToken(client, rest, mode);
     default:
       return fail(`artifacts: '${group}' is not an artifacts command. See 'artifacts help'.`);
   }
@@ -322,17 +326,17 @@ export function credentialURL(remote: string, token: string): string {
 async function runRepo(
   client: ArtifactClient,
   args: string[],
-  scoped: boolean,
+  mode: ArtifactsHelpMode,
 ): Promise<ArtifactsCLIResult> {
   if (args.length === 0) {
-    return { stdout: repoHelp(scoped), stderr: "", exitCode: 1 };
+    return { stdout: repoHelp(mode), stderr: "", exitCode: 1 };
   }
   const [sub, ...rest] = args;
   switch (sub) {
     case "help":
     case "--help":
     case "-h":
-      return ok(repoHelp(scoped));
+      return ok(repoHelp(mode));
     case "create":
       return await runRepoCreate(client, rest);
     case "get":
@@ -472,17 +476,17 @@ async function runRepoImport(client: ArtifactClient, args: string[]): Promise<Ar
 async function runToken(
   client: ArtifactClient,
   args: string[],
-  scoped: boolean,
+  mode: ArtifactsHelpMode,
 ): Promise<ArtifactsCLIResult> {
   if (args.length === 0) {
-    return { stdout: tokenHelp(scoped), stderr: "", exitCode: 1 };
+    return { stdout: tokenHelp(mode), stderr: "", exitCode: 1 };
   }
   const [sub, ...rest] = args;
   switch (sub) {
     case "help":
     case "--help":
     case "-h":
-      return ok(tokenHelp(scoped));
+      return ok(tokenHelp(mode));
     case "create":
       return await runTokenCreate(client, rest);
     case "list":
@@ -591,11 +595,14 @@ async function runTokenDelete(client: ArtifactClient, args: string[]): Promise<A
 // help text
 // ---------------------------------------------------------------
 //
-// The two name paragraphs are the only thing scoping changes. A
-// client bound to a session works in local names; one bound to the
-// namespace works in stored names and sees every session's
-// repositories. Help states whichever is true, because a consumer
-// that believes the wrong one addresses the wrong repository.
+// The naming paragraph follows the client state. A client bound to
+// a session works in local names; one bound to the namespace works
+// in stored names and sees every session's repositories; one with
+// no binding has neither authority. Help states whichever is true,
+// because a consumer that believes the wrong one addresses the
+// wrong repository.
+
+type ArtifactsHelpMode = "session" | "namespace" | "unconfigured";
 
 const SCOPED_NAMES = `Every repository name you pass is implicitly scoped to this
 session: the name 'starter' addresses the repo stored as
@@ -611,12 +618,28 @@ including those a session owns (stored as '<session>__<name>'), and
 any of them can be read, written to, or deleted under that name.
 `;
 
-function topLevelHelp(scoped: boolean): string {
+const UNCONFIGURED_NAMES = `${ARTIFACTS_NOT_CONFIGURED_MESSAGE}.
+Configure WorkspaceOptions.artifacts before running repository or
+token commands.
+`;
+
+function namingHelp(mode: ArtifactsHelpMode): string {
+  switch (mode) {
+    case "session":
+      return SCOPED_NAMES;
+    case "namespace":
+      return UNSCOPED_NAMES;
+    case "unconfigured":
+      return UNCONFIGURED_NAMES;
+  }
+}
+
+function topLevelHelp(mode: ArtifactsHelpMode): string {
   return `usage: artifacts <command> [<args>]
 
 Manage Cloudflare Artifacts repositories and git tokens.
 
-${scoped ? SCOPED_NAMES : UNSCOPED_NAMES}
+${namingHelp(mode)}
 Commands:
    create  Create a repo, mint a token, and register a git remote.
    share   Mint a token and print one clone-ready remote URL.
@@ -660,15 +683,18 @@ Secrets: 'create', 'share', and 'token create' all surface a token
 `;
 }
 
-function repoHelp(scoped: boolean): string {
-  const nameKind = scoped ? "a local name" : "the stored name";
+function repoHelp(mode: ArtifactsHelpMode): string {
+  const nameKind =
+    mode === "session" ? "a local name" : mode === "namespace" ? "the stored name" : "its name";
+  const listScope =
+    mode === "session"
+      ? "this session's repository"
+      : mode === "namespace"
+        ? "the namespace's repository"
+        : "repository";
   return `usage: artifacts repo <subcommand> [<args>]
 
-${
-  scoped
-    ? "All names are session-scoped; pass local names only."
-    : "Names are namespace-wide; pass the name a repository is stored under."
-}
+${namingHelp(mode)}
 
    repo create <name> [--description <text>] [--default-branch <branch>] [--read-only]
        Create a repository. Prints JSON: { name, remote, defaultBranch, token }.
@@ -678,7 +704,7 @@ ${
        Print JSON metadata for a repository: ArtifactsRepoInfo with ${nameKind}.
 
    repo list
-       Print a JSON array of ${scoped ? "this session's" : "the namespace's"} repository metadata (without remote).
+       Print a JSON array of ${listScope} metadata (without remote).
 
    repo delete <name>
        Delete a repository. Prints a one-line confirmation.
@@ -692,15 +718,11 @@ Example:
 `;
 }
 
-function tokenHelp(scoped: boolean): string {
+function tokenHelp(mode: ArtifactsHelpMode): string {
   return `usage: artifacts token <subcommand> [<args>]
 
 Tokens authenticate git operations against a repository's remote.
-${
-  scoped
-    ? "The <repo> argument is a session-scoped local name."
-    : "The <repo> argument is the name a repository is stored under."
-}
+${namingHelp(mode)}
 
    token create <repo> [--scope read|write] [--ttl <dur>]
        Mint a token. Prints JSON: { id, plaintext, scope, expiresAt }.

--- a/packages/computer/src/artifacts/cli.ts
+++ b/packages/computer/src/artifacts/cli.ts
@@ -60,25 +60,29 @@ export async function runArtifactsCLI(
   input: ArtifactsCLIInput,
 ): Promise<ArtifactsCLIResult> {
   const argv = input.argv;
+  // Help describes the scoping the client actually applies, so every
+  // help path is told whether this client sits in one session or
+  // spans the namespace.
+  const scoped = client.sessionId !== undefined;
   if (argv.length === 0) {
     // Bare invocation: print help but signal misuse, the way `git`
     // with no args exits non-zero.
-    return { stdout: topLevelHelp(), stderr: "", exitCode: 1 };
+    return { stdout: topLevelHelp(scoped), stderr: "", exitCode: 1 };
   }
   const [group, ...rest] = argv;
   switch (group) {
     case "help":
     case "--help":
     case "-h":
-      return ok(topLevelHelp());
+      return ok(topLevelHelp(scoped));
     case "create":
       return await runCreate(client, rest, input.remoteAdd);
     case "share":
       return await runShare(client, rest);
     case "repo":
-      return await runRepo(client, rest);
+      return await runRepo(client, rest, scoped);
     case "token":
-      return await runToken(client, rest);
+      return await runToken(client, rest, scoped);
     default:
       return fail(`artifacts: '${group}' is not an artifacts command. See 'artifacts help'.`);
   }
@@ -315,16 +319,20 @@ export function credentialURL(remote: string, token: string): string {
 // repo group
 // ---------------------------------------------------------------
 
-async function runRepo(client: ArtifactClient, args: string[]): Promise<ArtifactsCLIResult> {
+async function runRepo(
+  client: ArtifactClient,
+  args: string[],
+  scoped: boolean,
+): Promise<ArtifactsCLIResult> {
   if (args.length === 0) {
-    return { stdout: repoHelp(), stderr: "", exitCode: 1 };
+    return { stdout: repoHelp(scoped), stderr: "", exitCode: 1 };
   }
   const [sub, ...rest] = args;
   switch (sub) {
     case "help":
     case "--help":
     case "-h":
-      return ok(repoHelp());
+      return ok(repoHelp(scoped));
     case "create":
       return await runRepoCreate(client, rest);
     case "get":
@@ -461,16 +469,20 @@ async function runRepoImport(client: ArtifactClient, args: string[]): Promise<Ar
 // token group
 // ---------------------------------------------------------------
 
-async function runToken(client: ArtifactClient, args: string[]): Promise<ArtifactsCLIResult> {
+async function runToken(
+  client: ArtifactClient,
+  args: string[],
+  scoped: boolean,
+): Promise<ArtifactsCLIResult> {
   if (args.length === 0) {
-    return { stdout: tokenHelp(), stderr: "", exitCode: 1 };
+    return { stdout: tokenHelp(scoped), stderr: "", exitCode: 1 };
   }
   const [sub, ...rest] = args;
   switch (sub) {
     case "help":
     case "--help":
     case "-h":
-      return ok(tokenHelp());
+      return ok(tokenHelp(scoped));
     case "create":
       return await runTokenCreate(client, rest);
     case "list":
@@ -578,17 +590,33 @@ async function runTokenDelete(client: ArtifactClient, args: string[]): Promise<A
 // ---------------------------------------------------------------
 // help text
 // ---------------------------------------------------------------
+//
+// The two name paragraphs are the only thing scoping changes. A
+// client bound to a session works in local names; one bound to the
+// namespace works in stored names and sees every session's
+// repositories. Help states whichever is true, because a consumer
+// that believes the wrong one addresses the wrong repository.
 
-function topLevelHelp(): string {
+const SCOPED_NAMES = `Every repository name you pass is implicitly scoped to this
+session: the name 'starter' addresses the repo stored as
+'<session>__starter'. You only ever work in local names; the session
+prefix is added on the way in and stripped on the way out. 'repo
+list' shows only this session's repositories.
+`;
+
+const UNSCOPED_NAMES = `This client is not scoped to a session: names are the ones the
+namespace stores, with nothing added on the way in or stripped on
+the way out. 'repo list' shows every repository in the namespace,
+including those a session owns (stored as '<session>__<name>'), and
+any of them can be read, written to, or deleted under that name.
+`;
+
+function topLevelHelp(scoped: boolean): string {
   return `usage: artifacts <command> [<args>]
 
-Manage Cloudflare Artifacts repositories and git tokens. Every
-repository name you pass is implicitly scoped to this session: the
-name 'starter' addresses the repo stored as '<session>__starter'.
-You only ever work in local names; the session prefix is added on
-the way in and stripped on the way out. 'repo list' shows only this
-session's repositories.
+Manage Cloudflare Artifacts repositories and git tokens.
 
+${scoped ? SCOPED_NAMES : UNSCOPED_NAMES}
 Commands:
    create  Create a repo, mint a token, and register a git remote.
    share   Mint a token and print one clone-ready remote URL.
@@ -632,10 +660,14 @@ Secrets: 'create', 'share', and 'token create' all surface a token
 `;
 }
 
-function repoHelp(): string {
+function repoHelp(scoped: boolean): string {
   return `usage: artifacts repo <subcommand> [<args>]
 
-All names are session-scoped; pass local names only.
+${
+  scoped
+    ? "All names are session-scoped; pass local names only."
+    : "Names are namespace-wide; pass the name a repository is stored under."
+}
 
    repo create <name> [--description <text>] [--default-branch <branch>] [--read-only]
        Create a repository. Prints JSON: { name, remote, defaultBranch, token }.
@@ -645,7 +677,7 @@ All names are session-scoped; pass local names only.
        Print JSON metadata for a repository: ArtifactsRepoInfo with a local name.
 
    repo list
-       Print a JSON array of this session's repository metadata (without remote).
+       Print a JSON array of ${scoped ? "this session's" : "the namespace's"} repository metadata (without remote).
 
    repo delete <name>
        Delete a repository. Prints a one-line confirmation.
@@ -659,11 +691,15 @@ Example:
 `;
 }
 
-function tokenHelp(): string {
+function tokenHelp(scoped: boolean): string {
   return `usage: artifacts token <subcommand> [<args>]
 
 Tokens authenticate git operations against a repository's remote.
-The <repo> argument is a session-scoped local name.
+${
+  scoped
+    ? "The <repo> argument is a session-scoped local name."
+    : "The <repo> argument is the name a repository is stored under."
+}
 
    token create <repo> [--scope read|write] [--ttl <dur>]
        Mint a token. Prints JSON: { id, plaintext, scope, expiresAt }.

--- a/packages/computer/src/artifacts/cli.ts
+++ b/packages/computer/src/artifacts/cli.ts
@@ -661,6 +661,7 @@ Secrets: 'create', 'share', and 'token create' all surface a token
 }
 
 function repoHelp(scoped: boolean): string {
+  const nameKind = scoped ? "a local name" : "the stored name";
   return `usage: artifacts repo <subcommand> [<args>]
 
 ${
@@ -674,7 +675,7 @@ ${
        The token is an initial git token — treat it as a secret.
 
    repo get <name>
-       Print JSON metadata for a repository: ArtifactsRepoInfo with a local name.
+       Print JSON metadata for a repository: ArtifactsRepoInfo with ${nameKind}.
 
    repo list
        Print a JSON array of ${scoped ? "this session's" : "the namespace's"} repository metadata (without remote).

--- a/packages/computer/src/artifacts/client.test.ts
+++ b/packages/computer/src/artifacts/client.test.ts
@@ -1,8 +1,12 @@
-// Tests for the session-scoped artifacts client. The fake binding
-// stores names verbatim, so these assert the scoping contract from
-// the outside: what the caller passes in (local names) versus what
-// lands in the namespace (session-prefixed names), and that reads
-// only ever surface the session's own repos with the prefix gone.
+// Tests for the artifacts client. The fake binding stores names
+// verbatim, so these assert the scoping contract from the outside:
+// what the caller passes in (local names) versus what lands in the
+// namespace (session-prefixed names), and that reads only ever
+// surface the session's own repos with the prefix gone.
+//
+// The last block covers the other mode, a client built with no
+// session id, where names go through untouched and every
+// repository in the namespace is in reach.
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { FakeArtifactsBinding } from "../../tests/utilities/fake-artifacts-binding.js";

--- a/packages/computer/src/artifacts/client.test.ts
+++ b/packages/computer/src/artifacts/client.test.ts
@@ -27,6 +27,81 @@ describe("createArtifact", () => {
     expect(() => createArtifact(binding, "a__b")).toThrow();
   });
 
+  describe("without a session id", () => {
+    // An unscoped client is the namespace-wide door: names are the
+    // ones the binding stores, nothing is prefixed on the way in or
+    // filtered on the way out, and repositories belonging to scoped
+    // sessions are ordinary repositories from here.
+
+    it("constructs from the binding alone", () => {
+      expect(() => createArtifact(binding)).not.toThrow();
+      expect(() => createArtifact(binding, null)).not.toThrow();
+    });
+
+    it("reports no session id", () => {
+      expect(createArtifact(binding).sessionId).toBeUndefined();
+    });
+
+    it("stores a created repo under the bare name", async () => {
+      const client = createArtifact(binding);
+      const result = await client.create("starter");
+      expect(result.name).toBe("starter");
+      expect(binding.has("starter")).toBe(true);
+    });
+
+    it("lists every repository in the namespace under its stored name", async () => {
+      await createArtifact(binding, "sess1").create("alpha");
+      await createArtifact(binding, "sess2").create("beta");
+      await createArtifact(binding).create("loose");
+
+      const repos = await createArtifact(binding).list();
+      expect(repos.map((r) => r.name).sort()).toEqual(["loose", "sess1__alpha", "sess2__beta"]);
+    });
+
+    it("walks every page while listing the whole namespace", async () => {
+      binding = new FakeArtifactsBinding({ pageSize: 1 });
+      await createArtifact(binding, "sess1").create("alpha");
+      await createArtifact(binding, "sess2").create("beta");
+
+      const repos = await createArtifact(binding).list();
+      expect(repos.map((r) => r.name).sort()).toEqual(["sess1__alpha", "sess2__beta"]);
+    });
+
+    it("reads a repository a scoped session created", async () => {
+      await createArtifact(binding, "sess1").create("starter");
+      const repo = await createArtifact(binding).get("sess1__starter");
+      expect(repo.name).toBe("sess1__starter");
+      expect(repo.remote).toContain("sess1__starter.git");
+    });
+
+    it("mints a token for a repository a scoped session created", async () => {
+      await createArtifact(binding, "sess1").create("starter");
+      const token = await createArtifact(binding).createToken("sess1__starter", "read");
+      expect(token.scope).toBe("read");
+      expect(token.plaintext).toMatch(/^art_v1_/);
+    });
+
+    it("deletes a repository a scoped session created", async () => {
+      await createArtifact(binding, "sess1").create("starter");
+      expect(await createArtifact(binding).delete("sess1__starter")).toBe(true);
+      expect(binding.has("sess1__starter")).toBe(false);
+    });
+
+    it("writes into a session's namespace when named explicitly", async () => {
+      // Namespace-wide access covers writes too: the name is taken
+      // literally, so a scoped client picks this repo up as its own.
+      await createArtifact(binding).create("sess1__adopted");
+      expect(await createArtifact(binding, "sess1").list()).toEqual([
+        expect.objectContaining({ name: "adopted" }),
+      ]);
+    });
+
+    it("stays invisible to a scoped client when the name is bare", async () => {
+      await createArtifact(binding).create("loose");
+      expect(await createArtifact(binding, "sess1").list()).toEqual([]);
+    });
+  });
+
   describe("create", () => {
     it("stores the scoped name in the namespace", async () => {
       const client = createArtifact(binding, "sess1");

--- a/packages/computer/src/artifacts/client.ts
+++ b/packages/computer/src/artifacts/client.ts
@@ -1,5 +1,5 @@
-// Session-scoped facade over the Cloudflare Artifacts Workers
-// binding.
+// Facade over the Cloudflare Artifacts Workers binding, optionally
+// scoped to a session.
 //
 // `createArtifact(binding, sessionId)` binds a namespace binding
 // and a session id once and returns a client whose every method is
@@ -8,6 +8,14 @@
 // namespace, and `list()` returns only the session's own repos with
 // the prefix stripped back off. A caller never sees the scoped form
 // — names go in and come out local.
+//
+// The session id is optional. `createArtifact(binding)` returns a
+// client over the namespace as a whole: names are the ones the
+// binding stores, `list()` returns every repository including the
+// ones scoped sessions minted, and any of them can be read, written
+// to, or deleted by its stored name. That is the right client for a
+// caller that administers a namespace rather than living in one
+// corner of it, and the wrong one to hand to a tenant.
 //
 // The binding, its repo handle, and the result shapes are the
 // global types from `@cloudflare/workers-types` (`Artifacts`,
@@ -22,7 +30,7 @@
 import type { ArtifactsCLIInput, ArtifactsCLIResult } from "./cli.js";
 import { runArtifactsCLI } from "./cli.js";
 import { NotFoundError } from "./errors.js";
-import { scopedName, scopePrefix, unscopedName } from "./scope.js";
+import { normalizeSessionId, scopedName, unscopedName } from "./scope.js";
 import type { ArtifactScope } from "./types.js";
 
 /** Source spec for `import`. Mirrors the binding's `source` block. */
@@ -45,10 +53,13 @@ export interface ArtifactImportOptions {
  */
 export type ArtifactRepoSummary = Omit<ArtifactsRepoInfo, "remote">;
 
-/** The session-scoped client. */
+/** The client, session-scoped or namespace-wide. */
 export interface ArtifactClient {
-  /** The session id every operation is scoped under. */
-  readonly sessionId: string;
+  /**
+   * The session id every operation is scoped under, or undefined
+   * when the client spans the whole namespace.
+   */
+  readonly sessionId: string | undefined;
 
   /** Create a repo. The returned `name` is local (unscoped). */
   create(
@@ -60,7 +71,11 @@ export interface ArtifactClient {
    * Throws `ArtifactsError` (code `NOT_FOUND`) if it does not exist.
    */
   get(name: string): Promise<ArtifactsRepoInfo>;
-  /** List the session's repos, walking every page. Names are local. */
+  /**
+   * List the session's repos, walking every page. Names are local.
+   * Without a session id this is every repo in the namespace, each
+   * under its stored name.
+   */
   list(): Promise<ArtifactRepoSummary[]>;
   /** Import an external git remote into a session repo. */
   import(
@@ -102,22 +117,29 @@ export interface ArtifactClient {
  */
 const LIST_PAGE_SIZE = 100;
 
-/** Build a session-scoped artifacts client over a namespace binding. */
-export function createArtifact(binding: Artifacts, sessionId: string): ArtifactClient {
-  // Validate the session id eagerly so a bad id fails at
+/**
+ * Build an artifacts client over a namespace binding. Pass a
+ * session id to scope every operation to that session; omit it for
+ * a client over the whole namespace.
+ */
+export function createArtifact(
+  binding: Artifacts,
+  sessionId?: string | null,
+): ArtifactClient {
+  // Resolve the scope eagerly so a bad session id fails at
   // construction rather than on first use.
-  scopePrefix(sessionId);
+  const scope = normalizeSessionId(sessionId);
 
   const client: ArtifactClient = {
-    sessionId,
+    sessionId: scope,
 
     async create(name, opts) {
-      const result = await binding.create(scopedName(sessionId, name), opts);
-      return { ...result, name: unscopeOr(sessionId, result.name, name) };
+      const result = await binding.create(scopedName(scope, name), opts);
+      return { ...result, name: unscopeOr(scope, result.name, name) };
     },
 
     async get(name) {
-      const handle = await binding.get(scopedName(sessionId, name));
+      const handle = await binding.get(scopedName(scope, name));
       // The handle is a live Workers-RPC stub (ArtifactsRepo extends
       // RpcTarget). The published `@cloudflare/workers-types` shape is
       // wrong in both directions: it models the metadata as inherited
@@ -139,7 +161,7 @@ export function createArtifact(binding: Artifacts, sessionId: string): ArtifactC
       while (!done) {
         const page = await binding.list({ limit: LIST_PAGE_SIZE, cursor });
         for (const repo of page.repos) {
-          const local = unscopedName(sessionId, repo.name);
+          const local = unscopedName(scope, repo.name);
           if (local !== undefined) out.push({ ...repo, name: local });
         }
         const next = page.cursor;
@@ -159,27 +181,27 @@ export function createArtifact(binding: Artifacts, sessionId: string): ArtifactC
     async import(name, source, opts) {
       const result = await binding.import({
         source,
-        target: { name: scopedName(sessionId, name), opts },
+        target: { name: scopedName(scope, name), opts },
       });
-      return { ...result, name: unscopeOr(sessionId, result.name, name) };
+      return { ...result, name: unscopeOr(scope, result.name, name) };
     },
 
     async delete(name) {
-      return binding.delete(scopedName(sessionId, name));
+      return binding.delete(scopedName(scope, name));
     },
 
-    async createToken(name, scope, ttl) {
-      const handle = await binding.get(scopedName(sessionId, name));
-      return handle.createToken(scope, ttl);
+    async createToken(name, tokenScope, ttl) {
+      const handle = await binding.get(scopedName(scope, name));
+      return handle.createToken(tokenScope, ttl);
     },
 
     async listTokens(name) {
-      const handle = await binding.get(scopedName(sessionId, name));
+      const handle = await binding.get(scopedName(scope, name));
       return handle.listTokens();
     },
 
     async getToken(name, id) {
-      const handle = await binding.get(scopedName(sessionId, name));
+      const handle = await binding.get(scopedName(scope, name));
       const { tokens } = await handle.listTokens();
       const found = tokens.find((t) => t.id === id);
       if (!found) {
@@ -189,7 +211,7 @@ export function createArtifact(binding: Artifacts, sessionId: string): ArtifactC
     },
 
     async revokeToken(name, tokenOrId) {
-      const handle = await binding.get(scopedName(sessionId, name));
+      const handle = await binding.get(scopedName(scope, name));
       return handle.revokeToken(tokenOrId);
     },
 
@@ -228,6 +250,6 @@ function repoInfo(info: ArtifactsRepoInfo, localName: string): ArtifactsRepoInfo
  * stored; if it ever returns something without our prefix, prefer
  * the caller's local name over leaking a foreign-looking value.
  */
-function unscopeOr(sessionId: string, returned: string, fallback: string): string {
+function unscopeOr(sessionId: string | undefined, returned: string, fallback: string): string {
   return unscopedName(sessionId, returned) ?? fallback;
 }

--- a/packages/computer/src/artifacts/client.ts
+++ b/packages/computer/src/artifacts/client.ts
@@ -1,4 +1,4 @@
-// Facade over the Cloudflare Artifacts Workers binding, optionally
+// Wrapper over the Cloudflare Artifacts Workers binding, optionally
 // scoped to a session.
 //
 // `createArtifact(binding, sessionId)` binds a namespace binding
@@ -20,7 +20,7 @@
 // The binding, its repo handle, and the result shapes are the
 // global types from `@cloudflare/workers-types` (`Artifacts`,
 // `ArtifactsRepo`, `ArtifactsCreateRepoResult`, `ArtifactsRepoInfo`,
-// ...). The facade adds session scoping on top; it does not
+// ...). The wrapper adds session scoping on top; it does not
 // redeclare the wire shapes.
 //
 // The typed surface here is the single source of truth. The argv-

--- a/packages/computer/src/artifacts/client.ts
+++ b/packages/computer/src/artifacts/client.ts
@@ -122,10 +122,7 @@ const LIST_PAGE_SIZE = 100;
  * session id to scope every operation to that session; omit it for
  * a client over the whole namespace.
  */
-export function createArtifact(
-  binding: Artifacts,
-  sessionId?: string | null,
-): ArtifactClient {
+export function createArtifact(binding: Artifacts, sessionId?: string | null): ArtifactClient {
   // Resolve the scope eagerly so a bad session id fails at
   // construction rather than on first use.
   const scope = normalizeSessionId(sessionId);

--- a/packages/computer/src/artifacts/errors.ts
+++ b/packages/computer/src/artifacts/errors.ts
@@ -1,5 +1,7 @@
 // Typed error hierarchy for the artifacts surface.
-//
+
+export const ARTIFACTS_NOT_CONFIGURED_MESSAGE = "Workspace Artifacts binding is not configured";
+
 // The CLI dispatcher in `cli.ts` maps each class to a
 // deterministic exit code and a stderr line so a shell consumer
 // can match on the text. The hierarchy is deliberately narrow:

--- a/packages/computer/src/artifacts/errors.ts
+++ b/packages/computer/src/artifacts/errors.ts
@@ -1,4 +1,4 @@
-// Typed error hierarchy for the session-scoped artifacts surface.
+// Typed error hierarchy for the artifacts surface.
 //
 // The CLI dispatcher in `cli.ts` maps each class to a
 // deterministic exit code and a stderr line so a shell consumer
@@ -35,6 +35,11 @@ export class InvalidRepoNameError extends ArtifactError {
  * Raised when a session id is empty or contains a path separator.
  * A session id becomes the leading segment of every scoped name,
  * so it has the same shape constraints as a repo name.
+ *
+ * An empty id is an error rather than a way to ask for a client
+ * without a session. That is what omitting the id does, and an id
+ * that came out empty by accident should not silently widen a
+ * client from one session to the whole namespace.
  */
 export class InvalidSessionIdError extends ArtifactError {
   constructor(sessionId: string, reason: string, options?: { cause?: unknown }) {

--- a/packages/computer/src/artifacts/index.ts
+++ b/packages/computer/src/artifacts/index.ts
@@ -6,6 +6,10 @@
 // session — repository names are prefixed on the way in and
 // stripped on the way out, so callers work entirely in local names.
 //
+// The session id is optional. Without one the client spans the
+// namespace: names are the ones the binding stores, and every
+// repository is listed and reachable, including those sessions own.
+//
 // The typed client and the argv-driven CLI (`client.cli(...)`)
 // share one implementation. The worker backend's `artifacts` custom
 // command dispatches through the CLI so the in-shell tool and the

--- a/packages/computer/src/artifacts/scope.test.ts
+++ b/packages/computer/src/artifacts/scope.test.ts
@@ -7,7 +7,9 @@ import { describe, expect, it } from "vitest";
 import { InvalidRepoNameError, InvalidSessionIdError } from "./errors.js";
 import {
   assertLocalName,
+  assertRepoName,
   assertSessionId,
+  normalizeSessionId,
   scopedName,
   scopePrefix,
   unscopedName,
@@ -45,6 +47,48 @@ describe("scopedName", () => {
   });
 });
 
+describe("normalizeSessionId", () => {
+  it("returns undefined when no session id is given", () => {
+    expect(normalizeSessionId(undefined)).toBeUndefined();
+    expect(normalizeSessionId(null)).toBeUndefined();
+  });
+
+  it("returns a valid session id unchanged", () => {
+    expect(normalizeSessionId("sess1")).toBe("sess1");
+  });
+
+  it("rejects an empty session id rather than reading it as absent", () => {
+    // An id that came out empty by accident (an unset template
+    // variable, say) would otherwise widen the client to the whole
+    // namespace in silence. Absence has to be spelled out.
+    expect(() => normalizeSessionId("")).toThrow(InvalidSessionIdError);
+  });
+
+  it("rejects a malformed session id", () => {
+    expect(() => normalizeSessionId("a__b")).toThrow(InvalidSessionIdError);
+    expect(() => normalizeSessionId("a/b")).toThrow(InvalidSessionIdError);
+  });
+});
+
+describe("scopedName without a session id", () => {
+  it("passes a name through verbatim", () => {
+    expect(scopedName(undefined, "starter")).toBe("starter");
+  });
+
+  it("accepts a name carrying another session's prefix", () => {
+    // An unscoped client addresses every repository in the
+    // namespace, including the ones a scoped session minted, so the
+    // separator is an ordinary character here.
+    expect(scopedName(undefined, "sess1__starter")).toBe("sess1__starter");
+  });
+
+  it("still rejects a name the binding itself would reject", () => {
+    expect(() => scopedName(undefined, "")).toThrow(InvalidRepoNameError);
+    expect(() => scopedName(undefined, "a/b")).toThrow(InvalidRepoNameError);
+    expect(() => scopedName(undefined, "-bad")).toThrow(InvalidRepoNameError);
+  });
+});
+
 describe("unscopedName", () => {
   it("strips the session prefix and returns the local name", () => {
     expect(unscopedName("sess1", "sess1__starter")).toBe("starter");
@@ -77,9 +121,35 @@ describe("unscopedName", () => {
   });
 });
 
+describe("unscopedName without a session id", () => {
+  it("returns a bare name verbatim", () => {
+    expect(unscopedName(undefined, "starter")).toBe("starter");
+  });
+
+  it("keeps a name belonging to a session instead of filtering it", () => {
+    // This is what makes `list()` namespace-wide: nothing is foreign
+    // to a client that has no session of its own.
+    expect(unscopedName(undefined, "sess1__starter")).toBe("sess1__starter");
+    expect(unscopedName(undefined, "sess1__a__b")).toBe("sess1__a__b");
+  });
+});
+
 describe("scopePrefix", () => {
   it("is the session id followed by the scope separator", () => {
     expect(scopePrefix("sess1")).toBe("sess1__");
+  });
+});
+
+describe("assertRepoName", () => {
+  it("permits the scope separator a local name forbids", () => {
+    expect(assertRepoName("sess1__starter")).toBe("sess1__starter");
+    expect(() => assertLocalName("sess1__starter")).toThrow(InvalidRepoNameError);
+  });
+
+  it("rejects the characters the binding rejects", () => {
+    expect(() => assertRepoName("")).toThrow(InvalidRepoNameError);
+    expect(() => assertRepoName("a/b")).toThrow(InvalidRepoNameError);
+    expect(() => assertRepoName("_leading")).toThrow(InvalidRepoNameError);
   });
 });
 

--- a/packages/computer/src/artifacts/scope.ts
+++ b/packages/computer/src/artifacts/scope.ts
@@ -3,8 +3,8 @@
 // Scoping is optional, so these helpers take a session id that may
 // be undefined and behave in one of two modes.
 //
-// With a session id, every name a caller passes to the facade is
-// local — `starter`, `react-mirror`. The facade prefixes the session
+// With a session id, every name a caller passes to the wrapper is
+// local — `starter`, `react-mirror`. The wrapper prefixes the session
 // id to form the fully-qualified name the binding stores:
 // `${sessionId}__${name}`. Reads run the inverse: a scoped name is
 // stripped back to its local form, and any name that doesn't belong
@@ -30,7 +30,7 @@ const VALID_REPO_NAME_DESCRIPTION =
   "must start with a letter or digit and contain only letters, digits, '.', '_', and '-'";
 
 /**
- * Resolve an optional session id to the scope the facade runs in:
+ * Resolve an optional session id to the scope the wrapper runs in:
  * a validated session id, or undefined for an unscoped client that
  * sees the whole namespace.
  *
@@ -119,7 +119,7 @@ export function unscopedName(sessionId: string | undefined, scoped: string): str
   const local = scoped.slice(prefix.length);
   // A scoped name with a nested separator (`sess__a__b`) does not
   // round-trip through `scopedName`, so it can't have been minted
-  // by this facade. Treat it as foreign.
+  // by this wrapper. Treat it as foreign.
   if (local.length === 0 || local.includes(SCOPE_SEPARATOR)) return undefined;
   return local;
 }

--- a/packages/computer/src/artifacts/scope.ts
+++ b/packages/computer/src/artifacts/scope.ts
@@ -1,11 +1,20 @@
 // Session scoping for artifact repository names.
 //
-// Every name a caller passes to the facade is local — `starter`,
-// `react-mirror`. The facade prefixes the session id to form the
-// fully-qualified name the binding stores: `${sessionId}__${name}`.
-// Reads run the inverse: a scoped name is stripped back to its
-// local form, and any name that doesn't belong to the session is
-// filtered out.
+// Scoping is optional, so these helpers take a session id that may
+// be undefined and behave in one of two modes.
+//
+// With a session id, every name a caller passes to the facade is
+// local — `starter`, `react-mirror`. The facade prefixes the session
+// id to form the fully-qualified name the binding stores:
+// `${sessionId}__${name}`. Reads run the inverse: a scoped name is
+// stripped back to its local form, and any name that doesn't belong
+// to the session is filtered out.
+//
+// Without one, names pass through untouched in both directions and
+// nothing is filtered, so the caller addresses every repository in
+// the namespace — including the ones scoped sessions minted. Those
+// carry the separator in their stored name, so an unscoped name is
+// held only to the charset the binding itself enforces.
 //
 // Artifacts repository names may contain letters, digits, `.`, `_`,
 // and `-`, but not `/`. The scope separator is therefore a double
@@ -19,6 +28,21 @@ export const SCOPE_SEPARATOR = "__";
 const VALID_REPO_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const VALID_REPO_NAME_DESCRIPTION =
   "must start with a letter or digit and contain only letters, digits, '.', '_', and '-'";
+
+/**
+ * Resolve an optional session id to the scope the facade runs in:
+ * a validated session id, or undefined for an unscoped client that
+ * sees the whole namespace.
+ *
+ * Only an omitted (or explicitly null) id means unscoped. An empty
+ * string is a validation error, not a synonym for absence: an id
+ * that came out empty by accident would otherwise widen a client
+ * from one session to every session in the namespace in silence.
+ */
+export function normalizeSessionId(sessionId: string | null | undefined): string | undefined {
+  if (sessionId === undefined || sessionId === null) return undefined;
+  return assertSessionId(sessionId);
+}
 
 /** Validate a session id and return it, or throw. */
 export function assertSessionId(sessionId: string): string {
@@ -48,8 +72,29 @@ export function assertLocalName(name: string): string {
   return name;
 }
 
-/** Build the fully-qualified name the binding stores. */
-export function scopedName(sessionId: string, name: string): string {
+/**
+ * Validate a name for an unscoped client and return it, or throw.
+ * The only rule is the binding's own charset: such a client works
+ * in the namespace's stored names, and those include the
+ * separator-bearing names scoped sessions mint.
+ */
+export function assertRepoName(name: string): string {
+  if (name.length === 0) {
+    throw new InvalidRepoNameError(name, "must not be empty");
+  }
+  if (!VALID_REPO_NAME.test(name)) {
+    throw new InvalidRepoNameError(name, VALID_REPO_NAME_DESCRIPTION);
+  }
+  return name;
+}
+
+/**
+ * Build the name the binding stores. Under a session that is the
+ * fully-qualified `${sessionId}__${name}`; without one it is the
+ * caller's name unchanged.
+ */
+export function scopedName(sessionId: string | undefined, name: string): string {
+  if (sessionId === undefined) return assertRepoName(name);
   return `${assertSessionId(sessionId)}${SCOPE_SEPARATOR}${assertLocalName(name)}`;
 }
 
@@ -62,8 +107,13 @@ export function scopePrefix(sessionId: string): string {
  * Strip the session prefix from a scoped name. Returns undefined
  * when the name does not belong to the session, so a caller can
  * filter a mixed listing in one pass.
+ *
+ * Without a session id there is no prefix to strip and no such
+ * thing as a foreign name, so every name comes back as it is
+ * stored and a listing keeps all of its entries.
  */
-export function unscopedName(sessionId: string, scoped: string): string | undefined {
+export function unscopedName(sessionId: string | undefined, scoped: string): string | undefined {
+  if (sessionId === undefined) return scoped;
   const prefix = scopePrefix(sessionId);
   if (!scoped.startsWith(prefix)) return undefined;
   const local = scoped.slice(prefix.length);

--- a/packages/computer/src/artifacts/types.ts
+++ b/packages/computer/src/artifacts/types.ts
@@ -1,4 +1,4 @@
-// Facade-owned types for the artifacts surface.
+// Wrapper-owned types for the artifacts surface.
 //
 // The Cloudflare Artifacts Workers binding ships its own types in
 // `@cloudflare/workers-types`: the global `Artifacts` binding,
@@ -9,12 +9,12 @@
 // `ReadableStream` and other Workers globals. Consumers get the
 // types transitively through `@cloudflare/workers-types`.
 //
-// What lives here is the small set of types the facade itself owns
+// What lives here is the small set of types the wrapper itself owns
 // and that have no global equivalent.
 
 /**
  * Token scope. `write` grants push; `read` is fetch-only. Mirrors
  * the binding's `"read" | "write"` literal; named here so the
- * facade and CLI can refer to it by a single alias.
+ * wrapper and CLI can refer to it by a single alias.
  */
 export type ArtifactScope = "read" | "write";

--- a/packages/computer/src/artifacts/types.ts
+++ b/packages/computer/src/artifacts/types.ts
@@ -1,4 +1,4 @@
-// Facade-owned types for the session-scoped artifacts surface.
+// Facade-owned types for the artifacts surface.
 //
 // The Cloudflare Artifacts Workers binding ships its own types in
 // `@cloudflare/workers-types`: the global `Artifacts` binding,

--- a/packages/computer/src/index.ts
+++ b/packages/computer/src/index.ts
@@ -2,7 +2,7 @@
 //
 // The package runs inside a Cloudflare Worker / Durable
 // Object. It picks a backend, holds a SyncRPC connection to
-// computerd, and exposes a file-shaped facade.
+// computerd, and exposes a file-shaped wrapper.
 //
 // Backends ship under sub-path entries so the large built
 // dependencies they carry (a bundled just-bash for the worker

--- a/packages/computer/src/observe/cloudflare.test.ts
+++ b/packages/computer/src/observe/cloudflare.test.ts
@@ -86,7 +86,7 @@ describe("createCloudflareObserver", () => {
     expect(spans[0].attributes).toEqual({ "workspace.fs.path": "/" });
   });
 
-  it("hands the callback a span facade whose setAttribute reaches the runtime", async () => {
+  it("hands the callback a span wrapper whose setAttribute reaches the runtime", async () => {
     const { tracing, spans } = makeFakeTracing();
     const observer = createCloudflareObserver({ tracing });
     await observer.span("workspace.runtime.exec", {}, async (span) => {

--- a/packages/computer/src/observe/cloudflare.ts
+++ b/packages/computer/src/observe/cloudflare.ts
@@ -27,7 +27,7 @@
 // The shape of `WorkspaceObserver.span(name, attributes, run)` is a
 // faithful subset of `tracing.enterSpan(name, callback)`. The only
 // real work the adapter does is forward seed attributes onto the
-// runtime span and hand a `setAttribute`-shaped facade to the workspace
+// runtime span and hand a `setAttribute`-shaped wrapper to the workspace
 // callback. Errors propagate through `enterSpan` naturally; the
 // workspace's own `withSpan` helper records `error.name` /
 // `error.message` before re-throwing.
@@ -75,7 +75,7 @@ export function createCloudflareObserver(options: CloudflareObserverOptions): Wo
       // bug rather than a caller bug.
       return tracing.enterSpan(name, (runtimeSpan) => {
         applyAttributes(runtimeSpan, attributes);
-        // Wrap the runtime span in a `WorkspaceSpan` facade. The facade
+        // Present the runtime span as a `WorkspaceSpan`. The wrapper
         // forwards `setAttribute` directly; `undefined` values are
         // dropped so callers can pass optional fields without
         // conditionals.
@@ -102,7 +102,7 @@ function applyAttributes(
 }
 
 // Used when the runtime does not expose `Tracing`. The callback runs
-// inline and the span facade is a no-op, matching the package's default
+// inline and the span wrapper is a no-op, matching the package's default
 // `noopObserver`. Duplicated here rather than re-exported to keep the
 // adapter file self-contained and avoid pulling the package entry into
 // the import graph of every adapter consumer.

--- a/packages/computer/src/runtime/runtime.test.ts
+++ b/packages/computer/src/runtime/runtime.test.ts
@@ -39,7 +39,7 @@ function eventStream(events: WorkspaceRuntimeEvent[]): ReadableStream<WorkspaceR
 
 // A backend whose exec replays a fixed event sequence. Drives the
 // runtime's encoding transform and result drain — the work the host
-// shell facade used to own before every backend shared one path.
+// shell wrapper used to own before every backend shared one path.
 function replayBackend(events: WorkspaceRuntimeEvent[]): WorkspaceModuleBackendHandle {
   return {
     exec: vi.fn(async (input) => ({ id: input.id ?? "exec", events: eventStream(events) })),

--- a/packages/computer/src/stub.ts
+++ b/packages/computer/src/stub.ts
@@ -24,7 +24,7 @@
 // All the SyncRPC streaming (push / pushObjects / fetchObjects /
 // fetchChanges) happens on the capnweb wire inside the DO. What
 // crosses the Workers-RPC boundary here is only the high-level
-// value-shaped facade — writeFile / readFile / stat / exec —
+// value-shaped wrapper — writeFile / readFile / stat / exec —
 // because Workers RPC doesn't carry non-byte ReadableStreams or
 // capnweb stubs.
 //

--- a/packages/computer/src/workspace.test.ts
+++ b/packages/computer/src/workspace.test.ts
@@ -770,6 +770,20 @@ describe("Workspace backend selection", () => {
       expect(res.stderr).toContain("Workspace Artifacts binding is not configured");
     });
 
+    it("reports the missing binding in help instead of promising namespace access", async () => {
+      const ws = new Workspace({ storage: makeStorage() });
+      const top = await ws.artifacts.cli({ argv: ["help"] });
+      const repo = await ws.artifacts.cli({ argv: ["repo", "--help"] });
+      const token = await ws.artifacts.cli({ argv: ["token", "--help"] });
+
+      for (const result of [top, repo, token]) {
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain("Workspace Artifacts binding is not configured");
+        expect(result.stdout).not.toContain("every repository in the namespace");
+        expect(result.stdout).not.toContain("namespace-wide");
+      }
+    });
+
     it("scopes to the workspace session id", async () => {
       const binding = new FakeArtifactsBinding();
       const ws = new Workspace({

--- a/packages/computer/src/workspace.test.ts
+++ b/packages/computer/src/workspace.test.ts
@@ -2,9 +2,8 @@ import { SQLiteTestStorage } from "@cloudflare/dofs/testing";
 import { describe, expect, it, vi } from "vitest";
 
 import { FakeArtifactsBinding } from "../tests/utilities/fake-artifacts-binding.js";
-
-import type { BackendHandle, WorkspaceBackend } from "./backend.js";
 import { createArtifact } from "./artifacts/index.js";
+import type { BackendHandle, WorkspaceBackend } from "./backend.js";
 import { createGitClient } from "./git/index.js";
 import type { WorkspaceModuleBackend } from "./runtime/types.js";
 import { WorkspaceTransportError } from "./transport-failure.js";

--- a/packages/computer/src/workspace.test.ts
+++ b/packages/computer/src/workspace.test.ts
@@ -1,7 +1,10 @@
 import { SQLiteTestStorage } from "@cloudflare/dofs/testing";
 import { describe, expect, it, vi } from "vitest";
 
+import { FakeArtifactsBinding } from "../tests/utilities/fake-artifacts-binding.js";
+
 import type { BackendHandle, WorkspaceBackend } from "./backend.js";
+import { createArtifact } from "./artifacts/index.js";
 import { createGitClient } from "./git/index.js";
 import type { WorkspaceModuleBackend } from "./runtime/types.js";
 import { WorkspaceTransportError } from "./transport-failure.js";
@@ -766,6 +769,58 @@ describe("Workspace backend selection", () => {
       const res = await ws.artifacts.cli({ argv: ["repo", "list"] });
       expect(res.exitCode).toBe(1);
       expect(res.stderr).toContain("Workspace Artifacts binding is not configured");
+    });
+
+    it("scopes to the workspace session id", async () => {
+      const binding = new FakeArtifactsBinding();
+      const ws = new Workspace({
+        storage: makeStorage(),
+        sessionId: "sess1",
+        artifacts: { binding },
+      });
+      expect(ws.artifacts.sessionId).toBe("sess1");
+      await ws.artifacts.create("starter");
+      expect(binding.has("sess1__starter")).toBe(true);
+    });
+
+    it("prefers an explicit artifacts session id over the workspace one", async () => {
+      const binding = new FakeArtifactsBinding();
+      const ws = new Workspace({
+        storage: makeStorage(),
+        sessionId: "sess1",
+        artifacts: { binding, sessionId: "other" },
+      });
+      await ws.artifacts.create("starter");
+      expect(binding.has("other__starter")).toBe(true);
+    });
+
+    it("spans the namespace when no session id is configured", async () => {
+      const binding = new FakeArtifactsBinding();
+      await createArtifact(binding, "sess1").create("starter");
+      const ws = new Workspace({ storage: makeStorage(), artifacts: { binding } });
+      expect(ws.artifacts.sessionId).toBeUndefined();
+      expect(await ws.artifacts.list()).toEqual([
+        expect.objectContaining({ name: "sess1__starter" }),
+      ]);
+    });
+
+    it("spans the namespace when the artifacts session id is null", async () => {
+      // The opt-out for a workspace that has a session id of its own
+      // but wants artifacts across every session.
+      const binding = new FakeArtifactsBinding();
+      await createArtifact(binding, "sess1").create("starter");
+      const ws = new Workspace({
+        storage: makeStorage(),
+        sessionId: "sess2",
+        artifacts: { binding, sessionId: null },
+      });
+      expect(ws.artifacts.sessionId).toBeUndefined();
+      expect(await ws.artifacts.list()).toHaveLength(1);
+    });
+
+    it("reports no session id when no binding is configured", async () => {
+      const ws = new Workspace({ storage: makeStorage() });
+      expect(ws.artifacts.sessionId).toBeUndefined();
     });
   });
 

--- a/packages/computer/src/workspace.test.ts
+++ b/packages/computer/src/workspace.test.ts
@@ -793,10 +793,23 @@ describe("Workspace backend selection", () => {
       expect(binding.has("other__starter")).toBe(true);
     });
 
-    it("spans the namespace when no session id is configured", async () => {
+    it("spans the namespace when the workspace session id is omitted", async () => {
       const binding = new FakeArtifactsBinding();
       await createArtifact(binding, "sess1").create("starter");
       const ws = new Workspace({ storage: makeStorage(), artifacts: { binding } });
+      expect(ws.artifacts.sessionId).toBeUndefined();
+      expect(await ws.artifacts.list()).toEqual([
+        expect.objectContaining({ name: "sess1__starter" }),
+      ]);
+    });
+
+    it("spans the namespace when the workspace session id is undefined", async () => {
+      // An unset variable and a missing property both arrive here as
+      // undefined, which is the default namespace-wide mode.
+      const binding = new FakeArtifactsBinding();
+      await createArtifact(binding, "sess1").create("starter");
+      const sessionId: string | undefined = undefined;
+      const ws = new Workspace({ storage: makeStorage(), sessionId, artifacts: { binding } });
       expect(ws.artifacts.sessionId).toBeUndefined();
       expect(await ws.artifacts.list()).toEqual([
         expect.objectContaining({ name: "sess1__starter" }),
@@ -818,8 +831,8 @@ describe("Workspace backend selection", () => {
     });
 
     it("rejects an empty workspace session id instead of widening the client", () => {
-      // A session id derived from an unset variable or a missing
-      // request field must not turn into namespace-wide access.
+      // Blank input, or a caller that normalizes a missing value to
+      // "", must not turn into namespace-wide access.
       const binding = new FakeArtifactsBinding();
       expect(
         () => new Workspace({ storage: makeStorage(), sessionId: "", artifacts: { binding } }),

--- a/packages/computer/src/workspace.test.ts
+++ b/packages/computer/src/workspace.test.ts
@@ -2,7 +2,7 @@ import { SQLiteTestStorage } from "@cloudflare/dofs/testing";
 import { describe, expect, it, vi } from "vitest";
 
 import { FakeArtifactsBinding } from "../tests/utilities/fake-artifacts-binding.js";
-import { createArtifact } from "./artifacts/index.js";
+import { createArtifact, InvalidSessionIdError } from "./artifacts/index.js";
 import type { BackendHandle, WorkspaceBackend } from "./backend.js";
 import { createGitClient } from "./git/index.js";
 import type { WorkspaceModuleBackend } from "./runtime/types.js";
@@ -815,6 +815,27 @@ describe("Workspace backend selection", () => {
       });
       expect(ws.artifacts.sessionId).toBeUndefined();
       expect(await ws.artifacts.list()).toHaveLength(1);
+    });
+
+    it("rejects an empty workspace session id instead of widening the client", () => {
+      // A session id derived from an unset variable or a missing
+      // request field must not turn into namespace-wide access.
+      const binding = new FakeArtifactsBinding();
+      expect(
+        () => new Workspace({ storage: makeStorage(), sessionId: "", artifacts: { binding } }),
+      ).toThrow(InvalidSessionIdError);
+    });
+
+    it("rejects an empty artifacts session id", () => {
+      const binding = new FakeArtifactsBinding();
+      expect(
+        () =>
+          new Workspace({
+            storage: makeStorage(),
+            sessionId: "sess1",
+            artifacts: { binding, sessionId: "" },
+          }),
+      ).toThrow(InvalidSessionIdError);
     });
 
     it("reports no session id when no binding is configured", async () => {

--- a/packages/computer/src/workspace.ts
+++ b/packages/computer/src/workspace.ts
@@ -19,7 +19,7 @@ import {
   SQLiteWorkspaceProvider,
   WorkspaceFilesystem,
 } from "@cloudflare/dofs";
-
+import { ARTIFACTS_NOT_CONFIGURED_MESSAGE } from "./artifacts/errors.js";
 import {
   type ArtifactClient,
   ArtifactError,
@@ -1356,7 +1356,7 @@ function artifactsSessionId(options: WorkspaceOptions): string | null | undefine
 
 function createDisabledArtifactsClient(): ArtifactClient {
   const fail = () => {
-    throw new ArtifactError("ENOCONFIG", "Workspace Artifacts binding is not configured");
+    throw new ArtifactError("ENOCONFIG", ARTIFACTS_NOT_CONFIGURED_MESSAGE);
   };
   return {
     sessionId: undefined,
@@ -1370,7 +1370,7 @@ function createDisabledArtifactsClient(): ArtifactClient {
     getToken: fail,
     revokeToken: fail,
     async cli(input) {
-      return runArtifactsCLI(this, input);
+      return runArtifactsCLI(this, input, false);
     },
   } as ArtifactClient;
 }

--- a/packages/computer/src/workspace.ts
+++ b/packages/computer/src/workspace.ts
@@ -184,10 +184,10 @@ export interface WorkspaceOptions {
   // own. Scope it unless the caller is meant to administer the
   // namespace.
   //
-  // An empty session id is a construction error rather than a way
-  // to ask for the namespace-wide client, so an id that came out
-  // blank by accident cannot widen one tenant's client to all of
-  // them.
+  // An omitted or undefined session id intentionally asks for the
+  // namespace-wide client. An empty string is a construction error
+  // instead, so blank input or code that normalizes a missing value
+  // to "" cannot widen one tenant's client to all of them.
   artifacts?: {
     binding: Artifacts;
     sessionId?: string | null;
@@ -1340,12 +1340,13 @@ function positiveRetryOption(value: number | undefined, fallback: number, name: 
  * artifacts-specific one when the caller set it, otherwise the
  * workspace's own, and undefined for a namespace-wide client.
  *
- * An empty id is passed through rather than read as an absent one.
- * A caller that derives the session id from an unset variable or a
- * missing request field gets the wrapper's `InvalidSessionIdError`
- * at construction instead of a client that reaches every
- * repository in the namespace. Ask for that client by omitting the
- * id or passing `null`.
+ * An omitted or undefined id intentionally asks for the
+ * namespace-wide client. An empty id is passed through rather than
+ * read as absent, so blank input or code such as
+ * `sessionId: value ?? ""` gets the wrapper's
+ * `InvalidSessionIdError` instead of widening access. Passing
+ * `null` is the explicit opt-out when the workspace has a session
+ * id of its own.
  */
 function artifactsSessionId(options: WorkspaceOptions): string | null | undefined {
   const configured = options.artifacts?.sessionId;

--- a/packages/computer/src/workspace.ts
+++ b/packages/computer/src/workspace.ts
@@ -1,4 +1,4 @@
-// Host-side Workspace facade.
+// Host-side Workspace wrapper.
 //
 // Runs inside a Cloudflare Worker / Durable Object. Owns a local
 // dofs Database (the host store) and a SyncRPC connection
@@ -190,7 +190,7 @@ export interface WorkspaceOptions {
 
   // Add Think's string-oriented WorkspaceLike filesystem methods
   // directly to the Workspace instance. This is off by default so
-  // the primary Workspace API stays on the `workspace.fs` facade;
+  // the primary Workspace API stays on the `workspace.fs` wrapper;
   // enable it when assigning a Workspace to `Think.workspace`.
   useThink?: boolean;
 }
@@ -279,7 +279,7 @@ export class Workspace {
   // runs again. This prevents a concurrent caller from reaching a
   // backend's own cache while it still points at the stale handle.
   readonly #disconnecting = new Map<string, Promise<void>>();
-  // Per-backend CommandExecutor facades. Constructed alongside each
+  // Per-backend CommandExecutor wrappers. Constructed alongside each
   // handle; reused for the life of the handle.
   readonly #shells = new Map<string, CommandExecutor>();
   // Cached command adapters presenting a CommandExecutor as the
@@ -406,14 +406,14 @@ export class Workspace {
   }
 
   // Observer used to wrap workspace operations in spans. Exposed for the
-  // stub and shell facades, which need to wrap their own entry points in
+  // stub and shell wrappers, which put their own entry points in
   // spans named after the boundary the caller crossed. Defaults to a
   // no-op when the constructor did not receive one.
   get observer(): WorkspaceObserver {
     return this.#observer;
   }
 
-  // Filesystem facade — the documented Workspace.fs surface from
+  // Filesystem wrapper — the documented Workspace.fs surface from
   // docs/04. Available immediately; doesn't need ready() because
   // reads and writes hit the local store, not the wire.
   //
@@ -446,7 +446,7 @@ export class Workspace {
     return this.#assets;
   }
 
-  // Git facade. Opt-in so the default Workspace graph does not
+  // Git wrapper. Opt-in so the default Workspace graph does not
   // carry isomorphic-git. When configured, it does not require a
   // backend — every supported subcommand reads and writes through
   // the local SQLite-backed VFS. The configured factory decides
@@ -1337,7 +1337,7 @@ function positiveRetryOption(value: number | undefined, fallback: number, name: 
  *
  * `WorkspaceOptions.sessionId` documents the empty string as its
  * unset value, so an empty id here means the workspace has no
- * session to scope by rather than a session named "". The facade
+ * session to scope by rather than a session named "". The wrapper
  * itself is stricter: it rejects an empty id outright, since a
  * caller reaching it directly has no such convention.
  */

--- a/packages/computer/src/workspace.ts
+++ b/packages/computer/src/workspace.ts
@@ -170,14 +170,22 @@ export interface WorkspaceOptions {
   assets?: AssetsClient | ((ws: Workspace) => AssetsClient);
 
   // Optional Cloudflare Artifacts binding. When configured,
-  // `workspace.artifacts` is a session-scoped Artifacts client.
-  // The session id defaults to WorkspaceOptions.sessionId; pass
-  // `artifacts.sessionId` to override it. When omitted, accessing
-  // the client is still possible but every operation fails with a
-  // clear configuration error.
+  // `workspace.artifacts` is an Artifacts client. When omitted,
+  // accessing the client is still possible but every operation
+  // fails with a clear configuration error.
+  //
+  // The client is scoped to a session when one is available: the
+  // session id defaults to WorkspaceOptions.sessionId, and
+  // `artifacts.sessionId` overrides it. With neither — or with an
+  // explicit `artifacts.sessionId: null`, the opt-out for a
+  // workspace that has a session id but wants artifacts across
+  // every session — the client spans the whole namespace: it lists
+  // and reaches every repository, including those other sessions
+  // own. Scope it unless the caller is meant to administer the
+  // namespace.
   artifacts?: {
     binding: Artifacts;
-    sessionId?: string;
+    sessionId?: string | null;
   };
 
   // Add Think's string-oriented WorkspaceLike filesystem methods
@@ -328,10 +336,7 @@ export class Workspace {
     this.#defaultGitIdentity = options.defaultGitIdentity;
     this.#useThink = options.useThink ?? false;
     this.#artifacts = options.artifacts
-      ? createArtifact(
-          options.artifacts.binding,
-          options.artifacts.sessionId ?? options.sessionId ?? "",
-        )
+      ? createArtifact(options.artifacts.binding, artifactsSessionId(options))
       : createDisabledArtifactsClient();
     this.#db = new Database(options.storage);
     initializeSchema(this.#db, this.#now);
@@ -1325,12 +1330,29 @@ function positiveRetryOption(value: number | undefined, fallback: number, name: 
   return resolved;
 }
 
+/**
+ * Resolve the session id the artifacts client runs under: the
+ * artifacts-specific one when the caller set it, otherwise the
+ * workspace's own, and undefined for a namespace-wide client.
+ *
+ * `WorkspaceOptions.sessionId` documents the empty string as its
+ * unset value, so an empty id here means the workspace has no
+ * session to scope by rather than a session named "". The facade
+ * itself is stricter: it rejects an empty id outright, since a
+ * caller reaching it directly has no such convention.
+ */
+function artifactsSessionId(options: WorkspaceOptions): string | null | undefined {
+  const configured = options.artifacts?.sessionId;
+  if (configured !== undefined) return configured;
+  return options.sessionId === "" ? undefined : options.sessionId;
+}
+
 function createDisabledArtifactsClient(): ArtifactClient {
   const fail = () => {
     throw new ArtifactError("ENOCONFIG", "Workspace Artifacts binding is not configured");
   };
   return {
-    sessionId: "",
+    sessionId: undefined,
     create: fail,
     get: fail,
     list: fail,

--- a/packages/computer/src/workspace.ts
+++ b/packages/computer/src/workspace.ts
@@ -183,6 +183,11 @@ export interface WorkspaceOptions {
   // and reaches every repository, including those other sessions
   // own. Scope it unless the caller is meant to administer the
   // namespace.
+  //
+  // An empty session id is a construction error rather than a way
+  // to ask for the namespace-wide client, so an id that came out
+  // blank by accident cannot widen one tenant's client to all of
+  // them.
   artifacts?: {
     binding: Artifacts;
     sessionId?: string | null;
@@ -1335,16 +1340,17 @@ function positiveRetryOption(value: number | undefined, fallback: number, name: 
  * artifacts-specific one when the caller set it, otherwise the
  * workspace's own, and undefined for a namespace-wide client.
  *
- * `WorkspaceOptions.sessionId` documents the empty string as its
- * unset value, so an empty id here means the workspace has no
- * session to scope by rather than a session named "". The wrapper
- * itself is stricter: it rejects an empty id outright, since a
- * caller reaching it directly has no such convention.
+ * An empty id is passed through rather than read as an absent one.
+ * A caller that derives the session id from an unset variable or a
+ * missing request field gets the wrapper's `InvalidSessionIdError`
+ * at construction instead of a client that reaches every
+ * repository in the namespace. Ask for that client by omitting the
+ * id or passing `null`.
  */
 function artifactsSessionId(options: WorkspaceOptions): string | null | undefined {
   const configured = options.artifacts?.sessionId;
   if (configured !== undefined) return configured;
-  return options.sessionId === "" ? undefined : options.sessionId;
+  return options.sessionId;
 }
 
 function createDisabledArtifactsClient(): ArtifactClient {

--- a/packages/computer/tests/utilities/fake-artifacts-binding.ts
+++ b/packages/computer/tests/utilities/fake-artifacts-binding.ts
@@ -9,7 +9,7 @@
 //
 // It is not a faithful emulation of the service: tokens are opaque
 // strings, ids are sequential, and there is no real git storage.
-// But it honors the contracts the facade depends on — repository
+// But it honors the contracts the wrapper depends on — repository
 // names must match the binding's documented charset, `list`
 // paginates across every repo and omits `remote`, and `revokeToken`
 // flips state.
@@ -231,7 +231,7 @@ class FakeRepoHandle implements ArtifactsRepo {
     name: string,
     _opts?: { description?: string; readOnly?: boolean; defaultBranchOnly?: boolean },
   ): Promise<ArtifactsCreateRepoResult> {
-    // Not exercised by the facade today; satisfy the interface.
+    // Not exercised by the wrapper today; satisfy the interface.
     throw makeError("INTERNAL_ERROR", `fork not implemented in fake: ${name}`);
   }
 }

--- a/packages/computerd/src/cli/computerd.test.ts
+++ b/packages/computerd/src/cli/computerd.test.ts
@@ -227,9 +227,9 @@ test("FUSE_MOUNT=shim materialises an RPC push under the mount point", async (_c
 
   const db = new Database(new SQLiteTestStorage());
   initializeSchema(db, Date.now);
-  const fsFacade = new WorkspaceFilesystem(db);
-  await fsFacade.mkdir(`${mountPoint}/repo`, { recursive: true });
-  await fsFacade.writeFile(`${mountPoint}/repo/a.txt`, "alpha");
+  const fsWrapper = new WorkspaceFilesystem(db);
+  await fsWrapper.mkdir(`${mountPoint}/repo`, { recursive: true });
+  await fsWrapper.writeFile(`${mountPoint}/repo/a.txt`, "alpha");
 
   // The exact rev count depends on how many ancestor directories
   // mkdir(recursive) had to materialise under the tmpdir mount

--- a/packages/computerd/src/shim/shim.ts
+++ b/packages/computerd/src/shim/shim.ts
@@ -141,7 +141,7 @@ export async function mountShim(options: MountShimOptions): Promise<ShimMount> {
   // implicitly when we break out below, or explicitly in unmount)
   // tears down the underlying interval.
   let stopped = false;
-  // watchAsync lives on the provider, not the VFS facade — the dofs
+  // watchAsync lives on the provider, not the VFS wrapper — the dofs
   // SQLiteWorkspaceProvider implements it via revision polling.
   const watcher = vfs.provider.watchAsync(mountPoint, { recursive: true }) as AsyncIterable<{
     eventType: "rename" | "change";


### PR DESCRIPTION
The artifacts client always needed a session id. That was fine for an agent that owns one corner of a namespace, but it left no way to look at the namespace as a whole, and a `Workspace` configured with an Artifacts binding and no session id threw from its constructor rather than giving you a client at all.

The session id is now optional. Leave it out and the client works in the names the namespace stores: `list()` returns every repository, including the ones sessions own under `<session>__<name>`, and each of those can be read, written to, or deleted by that name. Pass a session id and nothing changes. A `Workspace` picks the session up from its own `sessionId`, and `artifacts: { binding, sessionId: null }` asks for the namespace-wide client even when the workspace has a session of its own.

```ts
const mine = createArtifact(env.ARTIFACTS, "agent-7");
await mine.list(); // [{ name: "build-cache" }]

const all = createArtifact(env.ARTIFACTS);
await all.list();  // [{ name: "agent-7__build-cache" }, ...]
await all.delete("agent-7__build-cache");
```

That reach covers writes and deletes, so the unscoped client is for a caller that administers a namespace, not one that lives in it. To keep the two apart, an empty session id stays an error: only an omitted or `null` id means "no session", so an id that came out blank by accident fails instead of quietly opening up every session.

Names get one concession. A scoped client still refuses `__` in a name, since that separator is what makes the split unambiguous. An unscoped client has to accept it, because the stored names it works in contain it.

The scoping rules, the client, and the workspace wiring each landed with their own tests, and the in-shell `artifacts` command now prints help that matches the client it is bound to instead of promising a session prefix that may not be applied. Run `npm test --workspace @cloudflare/computer` to see the lot.

Two documentation notes. `docs/15_artifacts_interface.md` gained a section on the namespace-wide client, covering what its names mean and why a blank id is rejected. Separately, the word "facade" is gone from the prose across the repository in favor of "wrapper", which says the same thing without borrowing a pattern name.
