### PR TITLE
ci: Remove consumed container changeset

### DIFF
--- a/.changeset/container-launch-spec.md
+++ b/.changeset/container-launch-spec.md
@@ -1,5 +1,0 @@
----
-"@cloudflare/computer": minor
----
-
-Re-worked the WorkspaceContainerAPI interface to make it possible to configure egress.


### PR DESCRIPTION
The container launch changeset was included in the 0.3.0 changelog but survived the Version Packages merge. Changesets therefore includes the same change again in the 0.4.0 release plan.

Remove the consumed changeset. Running `npx changeset status` still plans the fixed packages at 0.4.0 and no longer includes the duplicate container launch summary.

This changes release metadata only, so no package tests were run. After merge, the release workflow will regenerate the Version Packages pull request from the six remaining changesets.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/computer/pull/143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->